### PR TITLE
WR#310007 - Add core_userlist_provider implementation

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -26,8 +26,10 @@ namespace search_elastic\privacy;
 defined('MOODLE_INTERNAL') || die();
 
 use core_privacy\local\metadata\collection;
+use core_privacy\local\request\approved_userlist;
 use core_privacy\local\request\contextlist;
 use core_privacy\local\request\approved_contextlist;
+use core_privacy\local\request\userlist;
 
 /**
  * Provider for the search_elastic plugin.
@@ -39,7 +41,9 @@ use core_privacy\local\request\approved_contextlist;
 class provider implements
     // This search engine plugin does not store any data itself.
     // It has no database tables, and it purely acts as a conduit, sending data externally.
-    \core_privacy\local\metadata\provider, \core_privacy\local\request\plugin\provider {
+    \core_privacy\local\metadata\provider,
+    \core_privacy\local\request\core_userlist_provider,
+    \core_privacy\local\request\plugin\provider {
 
     // This trait must be included to provide the relevant polyfill for the metadata provider.
     use \core_privacy\local\legacy_polyfill;
@@ -87,5 +91,21 @@ class provider implements
      * @param   approved_contextlist $contextlist The approved contexts and user information to delete information for.
      */
     public static function delete_data_for_user(approved_contextlist $contextlist) {
+    }
+
+    /**
+     * Get the list of users who have data within a context.
+     *
+     * @param   userlist $userlist The userlist containing the list of users who have data in this context/plugin combination.
+     */
+    public static function get_users_in_context(userlist $userlist) {
+    }
+
+    /**
+     * Delete multiple users within a single context.
+     *
+     * @param   approved_userlist $userlist The approved context and user information to delete information for.
+     */
+    public static function delete_data_for_users(approved_userlist $userlist) {
     }
 }


### PR DESCRIPTION
Moodle 3.6 requires the implementation of \core_privacy\local\request\core_userlist_provider