### PR TITLE
Added override for set_data_from_engine

### DIFF
--- a/classes/engine.php
+++ b/classes/engine.php
@@ -683,9 +683,9 @@ class engine extends \core_search\engine {
                 $this->totalresultdocs++;
             }
 
-            //  The search backend might have returned up to 10 times the results we need.
-            //  Therefore break out once we have all the results we need.
-            if($this->totalresultdocs >= \core_search\manager::MAX_RESULTS) {
+            // The search backend might have returned up to 10 times the results we need.
+            // Therefore break out once we have all the results we need.
+            if ($this->totalresultdocs >= \core_search\manager::MAX_RESULTS) {
                 break;
             }
 


### PR DESCRIPTION
Functionally identical to parent, apart from a small change in functionality when files are embedded inside of blocks