### PR TITLE
Addressed externallib issues with externallib_test.php for PHPUnit tests with MOODLE_402_STABLE

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -1,0 +1,124 @@
+name: Moodle plugin CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: 'mariadb'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: 'pgsql'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: 'mariadb'
+          - php: '8.0'
+            moodle-branch: 'master'
+            database: 'pgsql'
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+        ports:
+          - 5432:5432
+
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: zip, gd, mbstring, pgsql, mysqli
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Deploy moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          # Add dirs to $PATH
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          # PHPUnit depends on en_AU.UTF-8 locale
+          sudo locale-gen en_AU.UTF-8
+      - name: Install Moodle
+        # Need explicit IP to stop mysql client fail on attempt to use unix socket.
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+          IGNORE_PATHS: 'tool/printable/classes/bfpdf.php'
+
+      - name: phplint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: phpcpd
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd || true
+
+      - name: phpmd
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: codechecker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: validate
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: mustache
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt
+
+      - name: phpunit
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit
+
+      - name: behat
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome

--- a/externallib.php
+++ b/externallib.php
@@ -23,9 +23,16 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir . "/externallib.php");
+//require_once($CFG->libdir . "/externallib.php");
 
 use core_search\manager;
+use core_external\external_api;
+use core_external\external_format_value;
+use core_external\external_function_parameters;
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+use core_external\external_value;
+use core_external\external_warnings;
 
 /**
  * Elasticsearch Web Service


### PR DESCRIPTION
Fixed issue with the use of the external_api when PHPUnit testing with MOODLE_402_STABLE. (#97)
Added moodle-ci.yml file to run standard GHA tests.
This most likely will need it's own branch (e.g. MOODLE_402_STABLE) rather than merged.