### PR TITLE
issue #101: add support for Elastic Cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This plugin has been tested to work on the following cloud platforms:
 
 * [Microsoft Azure](https://azure.microsoft.com/en-au/)
 * [Amazon Webservices (AWS)](https://aws.amazon.com/)
+* [Elastic Cloud](https://www.elastic.co/)
 
 ## Generic Elasticsearch Setup
 To use this plugin first you will need to setup an Elaticsearch service.
@@ -143,6 +144,13 @@ To use Amazon Webservices (AWS) to provide an Elasticsearch service for Moodle:
 1. Create an AWS account: [Account creation guide](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
 2. Setup an Elasticsearch service: [AWS Elasticsearch setup guide](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html)
 
+
+## Elastic Cloud Setup
+
+To use Elastic Cloud to provide an Elasticsearch service for Moodle:
+1. Create an Elastic Cloud account and set up Elasticsearch: [Elasticsearch: Getting Started](https://www.elastic.co/webinars/getting-started-elasticsearch?baymax=default&elektra=docs&storm=top-video)
+2. Generate API Key for your search index and set this ket to the  moodle plugin settings.  
+
 ## Moodle Plugin Installation
 Once you have setup an Elasticsearch service you can now install the Moodle plugin.
 
@@ -162,8 +170,9 @@ These setup steps are the same regardless of how you have setup the Elasticsearc
 3. Configure the Elasticsearch plugin at: *Site administration > Plugins > Search > Elastic*
 4. Set *hostname* and *port* of your Elasticsearch server
 5. Optionally, change the *Request size* variable. Generally this can be left as is. Some Elasticsearch providers such as AWS have a limit on how big the HTTP payload can be. Therefore we limit it to a size in bytes.
-6. To create the index and populate Elasticsearch with your site's data, run this CLI script. `sudo -u www-data php search/cli/indexer.php --force`
-7. Enable Global search in *Site administration > Advanced features*
+6. Optionally, set API Key as some cloud platforms (e.g. Elastic Cloud) use it for authorizing HTTP requests.
+7. To create the index and populate Elasticsearch with your site's data, run this CLI script. `sudo -u www-data php search/cli/indexer.php --force`
+8Enable Global search in *Site administration > Advanced features*
 
 ## File Indexing Support
 This plugin uses [Apache Tika](https://tika.apache.org/) for file indexing support. Tika parses files, extracts the text, and return it via a REST API.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To use Amazon Webservices (AWS) to provide an Elasticsearch service for Moodle:
 
 To use Elastic Cloud to provide an Elasticsearch service for Moodle:
 1. Create an Elastic Cloud account and set up Elasticsearch: [Elasticsearch: Getting Started](https://www.elastic.co/webinars/getting-started-elasticsearch?baymax=default&elektra=docs&storm=top-video)
-2. Generate API Key for your search index and set this ket to the  moodle plugin settings.  
+2. Generate API Key for your search index and set this key to the moodle plugin settings.  
 
 ## Moodle Plugin Installation
 Once you have setup an Elasticsearch service you can now install the Moodle plugin.
@@ -172,7 +172,7 @@ These setup steps are the same regardless of how you have setup the Elasticsearc
 5. Optionally, change the *Request size* variable. Generally this can be left as is. Some Elasticsearch providers such as AWS have a limit on how big the HTTP payload can be. Therefore we limit it to a size in bytes.
 6. Optionally, set API Key as some cloud platforms (e.g. Elastic Cloud) use it for authorizing HTTP requests.
 7. To create the index and populate Elasticsearch with your site's data, run this CLI script. `sudo -u www-data php search/cli/indexer.php --force`
-8Enable Global search in *Site administration > Advanced features*
+8. Enable Global search in *Site administration > Advanced features*
 
 ## File Indexing Support
 This plugin uses [Apache Tika](https://tika.apache.org/) for file indexing support. Tika parses files, extracts the text, and return it via a REST API.

--- a/classes/engine.php
+++ b/classes/engine.php
@@ -270,7 +270,7 @@ class engine extends \core_search\engine {
             $responsecode = $response->getStatusCode();
         }
 
-        if ($responsecode != 200) {
+        if (isset($responsecode) && $responsecode != 200) {
             $returnval = get_string('noserver', 'search_elastic');
         }
 

--- a/classes/esrequest.php
+++ b/classes/esrequest.php
@@ -132,7 +132,9 @@ class esrequest {
      * @return \GuzzleHttp\Psr7\Response
      */
     public function get($url) {
-        $psr7request = new \GuzzleHttp\Psr7\Request('GET', $url);
+        $headers = $this->get_authorization_header();
+
+        $psr7request = new \GuzzleHttp\Psr7\Request('GET', $url, $headers);
 
         if ($this->signing) {
             $psr7request = $this->signrequest($psr7request);
@@ -152,7 +154,9 @@ class esrequest {
      * @return \GuzzleHttp\Psr7\Response
      */
     public function put($url, $params=null) {
-        $headers = ['content-type' => 'application/json'];
+        $headers = $this->get_authorization_header();
+        $headers['content-type'] = 'application/json';
+
         $psr7request = new \GuzzleHttp\Psr7\Request('PUT', $url, $headers, $params);
 
         if ($this->signing) {
@@ -172,7 +176,9 @@ class esrequest {
      * @return \Psr\Http\Message\ResponseInterface|NULL
      */
     public function post($url, $params) {
-        $headers = ['content-type' => 'application/json'];
+        $headers = $this->get_authorization_header();
+        $headers['content-type'] = 'application/json';
+
         $psr7request = new \GuzzleHttp\Psr7\Request('POST', $url, $headers, $params);
 
         if ($this->signing) {
@@ -193,7 +199,8 @@ class esrequest {
      * @return \Psr\Http\Message\ResponseInterface|NULL
      */
     public function postfile($url, $file) {
-        $headers = [];
+        $headers = $this->get_authorization_header();
+
         $contents = $file->get_content_file_handle();
         $multipart = new \GuzzleHttp\Psr7\MultipartStream([
                 [
@@ -217,7 +224,9 @@ class esrequest {
      * @return \Psr\Http\Message\ResponseInterface|NULL
      */
     public function delete($url) {
-        $psr7request = new \GuzzleHttp\Psr7\Request('DELETE', $url);
+        $headers = $this->get_authorization_header();
+
+        $psr7request = new \GuzzleHttp\Psr7\Request('DELETE', $url, $headers);
 
         if ($this->signing) {
             $psr7request = $this->signrequest($psr7request);
@@ -227,5 +236,19 @@ class esrequest {
 
         return $response;
 
+    }
+
+    /**
+     * Return authorization header.
+     *
+     * @return array|string[]
+     */
+    private function get_authorization_header() {
+        if (!empty($this->config->apikey)) {
+            return [
+                'Authorization' => 'ApiKey ' . $this->config->apikey,
+            ];
+        }
+        return [];
     }
 }

--- a/lang/en/search_elastic.php
+++ b/lang/en/search_elastic.php
@@ -27,6 +27,8 @@ $string['pluginname_help'] = 'Search backend for the Elasticsearch search engine
 
 $string['addfail'] = 'Failed to add document to index';
 $string['advsettings'] = 'Advanced settings';
+$string['apikey'] = 'API key';
+$string['apikey_help'] = 'Some Elasticsearch providers such as  Elastic Cloud require API key to authorize HTTP requests.';
 $string['aws'] = 'AWS';
 $string['adminsettings'] = 'Plugin settings';
 $string['basicsettings'] = 'Basic settings';
@@ -82,6 +84,7 @@ $string['privacy:metadata:data'] = 'Personal data passed through from the search
 $string['queryerror'] = 'Error executing query in search engine: {$a->reason}
 
 {$a->help}';
+$string['reachable'] = 'Elasticsearch endpoint reachable';
 $string['region'] = 'Region';
 $string['region_help'] = 'The AWS region the Elasticsearch instance is in, e.g. ap-southeast-2';
 $string['rekregion'] = 'Region';
@@ -107,7 +110,7 @@ $string['signingkeyid'] = 'Key ID';
 $string['signingkeyid_help'] = 'The ID of the key to use for signing requests.';
 $string['signingsecretkey'] = 'Secret Key';
 $string['signingsecretkey_help'] = 'The secret key to use to sign requests.';
-$string['signingsettings'] = 'Request signing settings';
+$string['signingsettings'] = 'Request signing settings (compatible with AWS)';
 $string['signingsettings_help'] = 'If your Elasticsearch setup uses Request Signing enable and configure it below.
 
 This generally only applies if you are using Amazon Web Service (AWS) to provide your Elasticsearch Endpoint';

--- a/settings.php
+++ b/settings.php
@@ -28,7 +28,16 @@ if ($hassiteconfig) {
     $ADMIN->add('searchplugins', new admin_category('search_elastic', get_string('pluginname', 'search_elastic')));
     $settings = new admin_settingpage('elasticsettings', get_string('adminsettings', 'search_elastic'));
 
-    $settings->add(new admin_setting_heading('basicsettings', get_string('basicsettings', 'search_elastic'), ''));
+    // Check status of the server.
+    $engine = new \search_elastic\engine();
+    $status = $engine->is_server_ready();
+    if ($status === true) {
+        $statustext = $OUTPUT->notification(get_string('reachable', 'search_elastic'), \core\output\notification::NOTIFY_SUCCESS);
+    } else {
+        $statustext = $OUTPUT->notification($status);
+    }
+
+    $settings->add(new admin_setting_heading('basicsettings', get_string('basicsettings', 'search_elastic'), $statustext));
     $settings->add(new admin_setting_configtext('search_elastic/hostname', get_string ('hostname', 'search_elastic'),
         get_string ('hostname_help', 'search_elastic'), 'http://127.0.0.1', PARAM_URL));
 
@@ -41,12 +50,8 @@ if ($hassiteconfig) {
     $settings->add(new admin_setting_configtext('search_elastic/sendsize', get_string ('sendsize', 'search_elastic'),
         get_string ('sendsize_help', 'search_elastic'), 9000000, PARAM_ALPHANUMEXT));
 
-    $settings->add(new admin_setting_heading('searchsettings', get_string('searchsettings', 'search_elastic'), ''));
-    $settings->add(new admin_setting_configcheckbox('search_elastic/wildcardend', get_string('wildcardend', 'search_elastic'),
-        get_string ('wildcardend_help', 'search_elastic'), 0));
-
-    $settings->add(new admin_setting_configcheckbox('search_elastic/wildcardstart', get_string('wildcardstart', 'search_elastic'),
-        get_string ('wildcardstart_help', 'search_elastic'), 0));
+    $settings->add(new admin_setting_configtext('search_elastic/apikey', get_string ('apikey', 'search_elastic'),
+        get_string ('apikey_help', 'search_elastic'), ''));
 
     $settings->add(new admin_setting_heading('signingsettings', get_string('signingsettings', 'search_elastic'), ''));
     $settings->add(new admin_setting_configcheckbox('search_elastic/signing', get_string('signing', 'search_elastic'),
@@ -61,6 +66,13 @@ if ($hassiteconfig) {
 
     $settings->add(new admin_setting_configtext('search_elastic/region', get_string ('region', 'search_elastic'),
         get_string ('region_help', 'search_elastic'), 'us-west-2', PARAM_TEXT));
+
+    $settings->add(new admin_setting_heading('searchsettings', get_string('searchsettings', 'search_elastic'), ''));
+    $settings->add(new admin_setting_configcheckbox('search_elastic/wildcardend', get_string('wildcardend', 'search_elastic'),
+        get_string ('wildcardend_help', 'search_elastic'), 0));
+
+    $settings->add(new admin_setting_configcheckbox('search_elastic/wildcardstart', get_string('wildcardstart', 'search_elastic'),
+        get_string ('wildcardstart_help', 'search_elastic'), 0));
 
     $settings->add(new admin_setting_heading('advsettings', get_string('advsettings', 'search_elastic'), ''));
     $settings->add(new admin_setting_configcheckbox('search_elastic/logging', get_string('logging', 'search_elastic'),


### PR DESCRIPTION
As part of this change we add a support for API key that is required for using the plugin with Elastic Cloud platform.

Also adding an instant feedback about plugin configuration.

![image](https://github.com/catalyst/moodle-search_elastic/assets/4626431/fa506e5f-7fde-43e1-bee0-8dfba6be7557)

![image](https://github.com/catalyst/moodle-search_elastic/assets/4626431/0f9cca0e-8986-4905-9d5f-eba25b63f45e)
