### PR TITLE
Connection timeout + check API integration

### DIFF
--- a/classes/admin_setting_check.php
+++ b/classes/admin_setting_check.php
@@ -18,6 +18,8 @@ namespace search_elastic;
 
 use admin_setting;
 use core\check\check;
+use core\check\result;
+use core\output\notification;
 
 /**
  * Admin setting for check api.
@@ -76,8 +78,18 @@ class admin_setting_check extends admin_setting {
 
         $resulthtml = $OUTPUT->check_result($checkresult);
         $resultinfo = $checkresult->get_summary();
-
         $out = $resulthtml . ' ' . $resultinfo;
+
+        switch($checkresult->get_status()){
+            case result::CRITICAL:
+            case result::ERROR:
+                $out = $OUTPUT->notification($out, notification::NOTIFY_ERROR, false);
+                break;
+
+            case result::OK:
+                $out = $OUTPUT->notification($out, notification::NOTIFY_SUCCESS, false);
+                break;
+        }
         return format_admin_setting($this, $this->visiblename, '', $out);
     }
 }

--- a/classes/admin_setting_check.php
+++ b/classes/admin_setting_check.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic;
+
+use admin_setting;
+use core\check\check;
+
+/**
+ * Admin setting for check api.
+ *
+ * @package     search_elastic
+ * @copyright   Matthew Hilton <matthew.hilton@catalyst-au.net>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class admin_setting_check extends admin_setting {
+    /** @var check $check The check to display */
+    private $check;
+
+    /**
+     * Creates check setting.
+     *
+     * @param string $name name of setting
+     * @param string $heading title of setting
+     * @param check $check check to display
+     */
+    public function __construct(string $name, string $heading, check $check) {
+        $this->nosave = true;
+        $this->check = $check;
+        parent::__construct($name, $heading, '', '');
+    }
+
+    /**
+     * Returns setting (unused)
+     *
+     * @return true
+     */
+    public function get_setting() {
+        return true;
+    }
+
+    /**
+     * Writes the setting (unused)
+     *
+     * @param mixed $data
+     */
+    public function write_setting($data) {
+        return '';
+    }
+
+    /**
+     * Ouputs the admin setting HTML to be rendered.
+     *
+     * @param mixed $data
+     * @param string $query
+     * @return string html
+     */
+    public function output_html($data, $query = '') {
+        global $OUTPUT;
+
+        // Run the check and get the result.
+        $checkresult = $this->check->get_result();
+
+        $resulthtml = $OUTPUT->check_result($checkresult);
+        $resultinfo = $checkresult->get_summary();
+
+        $out = $resulthtml . ' ' . $resultinfo;
+        return format_admin_setting($this, $this->visiblename, '', $out);
+    }
+}

--- a/classes/check/server_ready_check.php
+++ b/classes/check/server_ready_check.php
@@ -1,0 +1,82 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic\check;
+
+use action_link;
+use core\check\check;
+use core\check\result;
+use moodle_url;
+use search_elastic\engine;
+
+/**
+ * Elasticsearch plugin server ready check.
+ *
+ * @package     search_elastic
+ * @copyright   Matthew Hilton <matthew.hilton@catalyst-au.net>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class server_ready_check extends check {
+    /** @var object|false Custom Guzzle stack to use for requests. Used only for unit testing. */
+    private $stack;
+
+    /**
+     * Create check.
+     * @param object|false $stack Custom HTTP stack for unit testing.
+     */
+    public function __construct($stack = false) {
+        $this->stack = $stack;
+    }
+
+    /**
+     * Performs check and returns result.
+     *
+     * @return result
+     */
+    public function get_result(): result {
+        // Check the plugin is configured.
+        if (empty(get_config('search_elastic', 'hostname'))) {
+            return new result(result::NA, get_string('connection:na', 'search_elastic'));
+        }
+
+        // Query the server to see the HTTP response.
+        $engine = new engine();
+        $url = $engine->get_url();
+        $status = $engine->get_server_status_code($this->stack);
+        $resultstatus = $status === 200 ? result::OK : result::ERROR;
+
+        // Format the check details nicely.
+        $statusdetails = get_string('connection:status', 'search_elastic', [
+            'url' => $url,
+            'status' => $status
+        ]);
+
+        return new result($resultstatus, $statusdetails);
+    }
+
+    /**
+     * Returns the link to action this check if it failed.
+     *
+     * @return action_link A link to the elasticsearch engine plugin settings
+     */
+    public function get_action_link(): action_link {
+        $configstr = get_string('adminsettings', 'search_elastic');
+        $configurl = new moodle_url('/admin/settings.php', ['section' => 'elasticsettings']);
+
+        return new action_link($configurl, $configstr);
+    }
+}
+

--- a/classes/esrequest.php
+++ b/classes/esrequest.php
@@ -62,8 +62,11 @@ class esrequest {
         $this->config = get_config('search_elastic');
         $this->signing = (isset($this->config->signing) ? (bool)$this->config->signing : false);
 
+        $config = [
+            'connect_timeout' => intval($this->config->connecttimeout)
+        ];
+
         // Allow the caller to instantiate the Guzzle client with a custom handler.
-        $config = [];
         if ($handler) {
             $config['handler'] = $handler;
         }

--- a/lang/en/search_elastic.php
+++ b/lang/en/search_elastic.php
@@ -44,6 +44,8 @@ Wildcard characters (\'*\' or \'?\' ) may be used to represent characters in the
 <br>
 For more information, follow this link: {$a}';
 $string['complexhelpurl'] = 'https://lucene.apache.org/core/2_9_4/queryparsersyntax.html';
+$string['connecttimeout'] = 'Connect timeout (seconds)';
+$string['connecttimeout_help'] = 'Guzzle connection timeout. Use 0 to disable. See https://docs.guzzlephp.org/en/stable/request-options.html#connect-timeout';
 $string['enrichdesc'] = 'Global Search can enrich the indexed data used in search by extracting text and other data from files.
 The data extracted from files in Moodle is controlled by the following groups of settings.';
 $string['enrichsettings'] = 'Data enrichment settings';

--- a/lang/en/search_elastic.php
+++ b/lang/en/search_elastic.php
@@ -36,6 +36,8 @@ $string['boostdescription'] = 'These settings control the boosting settings for 
 $string['boostsettings'] = 'Boosting settings';
 $string['boostvalue'] = '';
 $string['boostvalue_help'] = 'Set the value you want this search area to be boosted by in the search results. Higher boost values give more priority.';
+$string['checkserver_ready_check'] = 'Elastic server connection';
+$string['connectiontest'] = 'Server connection test';
 $string['complexhelptext'] = 'The field to be searched may be specified by prefixing the search query with \'title:\', \'content:\', \'name:\', or \'intro:\'. For example, searching for \'title:news\' would return results with the word \'news\' in the title.
 <br>
 Boolean operators (\'AND\', \'OR\') may be used to combine or exclude keywords.

--- a/lang/en/search_elastic.php
+++ b/lang/en/search_elastic.php
@@ -44,6 +44,8 @@ Wildcard characters (\'*\' or \'?\' ) may be used to represent characters in the
 <br>
 For more information, follow this link: {$a}';
 $string['complexhelpurl'] = 'https://lucene.apache.org/core/2_9_4/queryparsersyntax.html';
+$string['connection:na'] = 'Server not configured';
+$string['connection:status'] = 'The configured elastic server at {$a->url} returned the status code {$a->status}';
 $string['connecttimeout'] = 'Connect timeout (seconds)';
 $string['connecttimeout_help'] = 'Guzzle connection timeout. Use 0 to disable. See https://docs.guzzlephp.org/en/stable/request-options.html#connect-timeout';
 $string['enrichdesc'] = 'Global Search can enrich the indexed data used in search by extracting text and other data from files.

--- a/lib.php
+++ b/lib.php
@@ -55,3 +55,11 @@ function search_elastic_extend_navigation_user() {
         redirect(new moodle_url('/search/engine/elastic/index.php'));
     }
 }
+
+/**
+ * Returns the status checks for this plugin.
+ * @return array
+ */
+function search_elastic_status_checks(): array {
+    return [new \search_elastic\check\server_ready_check()];
+}

--- a/settings.php
+++ b/settings.php
@@ -53,6 +53,9 @@ if ($hassiteconfig) {
     $settings->add(new admin_setting_configtext('search_elastic/apikey', get_string ('apikey', 'search_elastic'),
         get_string ('apikey_help', 'search_elastic'), ''));
 
+    $settings->add(new admin_setting_configtext('search_elastic/connecttimeout', get_string('connecttimeout', 'search_elastic'),
+        get_string('connecttimeout_help', 'search_elastic'), 5, PARAM_INT));
+
     $settings->add(new admin_setting_heading('signingsettings', get_string('signingsettings', 'search_elastic'), ''));
     $settings->add(new admin_setting_configcheckbox('search_elastic/signing', get_string('signing', 'search_elastic'),
         get_string ('signing_help', 'search_elastic'), 0));

--- a/settings.php
+++ b/settings.php
@@ -22,22 +22,24 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use search_elastic\admin_setting_check;
+use search_elastic\check\server_ready_check;
+
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
     $ADMIN->add('searchplugins', new admin_category('search_elastic', get_string('pluginname', 'search_elastic')));
     $settings = new admin_settingpage('elasticsettings', get_string('adminsettings', 'search_elastic'));
+    $settings->add(new admin_setting_heading('basicsettings', get_string('basicsettings', 'search_elastic'), ''));
 
-    // Check status of the server.
-    $engine = new \search_elastic\engine();
-    $status = $engine->is_server_ready();
-    if ($status === true) {
-        $statustext = $OUTPUT->notification(get_string('reachable', 'search_elastic'), \core\output\notification::NOTIFY_SUCCESS);
-    } else {
-        $statustext = $OUTPUT->notification($status);
+    // Only check status when when in full tree (i.e. not search)
+    // and only when viewing the elastic settings - this is because it can take a long time to run.
+    // We don't want it to run unnecessarily.
+    if ($ADMIN->fulltree && optional_param('section', null, PARAM_TEXT) == 'elasticsettings') {
+        $settings->add(new admin_setting_check('search_elastic/connectiontest', get_string('connectiontest', 'search_elastic'),
+            new server_ready_check()));
     }
 
-    $settings->add(new admin_setting_heading('basicsettings', get_string('basicsettings', 'search_elastic'), $statustext));
     $settings->add(new admin_setting_configtext('search_elastic/hostname', get_string ('hostname', 'search_elastic'),
         get_string ('hostname_help', 'search_elastic'), 'http://127.0.0.1', PARAM_URL));
 

--- a/tests/server_ready_check_test.php
+++ b/tests/server_ready_check_test.php
@@ -1,0 +1,93 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+namespace search_elastic;
+
+use advanced_testcase;
+use core\check\result;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use search_elastic\check\server_ready_check;
+
+/**
+ * Elasticsearch plugin server ready check tests
+ *
+ * @package     search_elastic
+ * @copyright   Matthew Hilton <matthew.hilton@catalyst-au.net>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers      \search_elastic\check\server_ready_check
+ */
+class server_ready_check_test extends advanced_testcase {
+
+    /** @var string Valid hostname for testing */
+    private const VALID_HOSTNAME = 'valid.com';
+
+    /** @var string Invalid hostname for testing */
+    private const INVALID_HOSTNAME = 'invalid.com';
+
+    /** @var string Empty hostname for testing */
+    private const EMPTY_HOSTNAME = '';
+
+    /**
+     * Provides server ready test configurations.
+     * @return array
+     */
+    public function server_ready_provider(): array {
+        return [
+            'not set' => [
+                'hostname' => self::EMPTY_HOSTNAME,
+                'status' => result::NA,
+            ],
+            'invalid hostname' => [
+                'hostname' => self::INVALID_HOSTNAME,
+                'status' => result::ERROR
+            ],
+            'valid hostname' => [
+                'hostname' => self::VALID_HOSTNAME,
+                'status' => result::OK
+            ]
+        ];
+    }
+
+    /**
+     * Tests check result.
+     *
+     * @param string $hostname
+     * @param string $expectedstatus
+     * @dataProvider server_ready_provider
+     */
+    public function test_check(string $hostname, string $expectedstatus) {
+        $this->resetAfterTest();
+        set_config('hostname', $hostname, 'search_elastic');
+
+        $testhostnamestatus = [
+            self::VALID_HOSTNAME => 200,
+            self::INVALID_HOSTNAME => 404,
+            self::EMPTY_HOSTNAME => 400
+        ];
+
+        $mock = new MockHandler([
+            new Response($testhostnamestatus[$hostname], ['Content-Type' => 'application/json'])
+        ]);
+        $stack = HandlerStack::create($mock);
+
+        $check = new server_ready_check($stack);
+        $result = $check->get_result();
+        $this->assertEquals($expectedstatus, $result->get_status());
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023012400;
+$plugin->version   = 2023090700;
 $plugin->release   = '4.1 Build (2023012400)'; // Build same as version.
 $plugin->requires  = 2016052304;
 $plugin->component = 'search_elastic';


### PR DESCRIPTION
## TLDR

- Adds connection timeout Closes #46
- Cleans up status check Closes #107

## Changes
- Configurable Guzzle http timeout set to default 5 seconds.
- Refactored the engine status check to provide better error messages (e.g. URL gave http code XYZ)
- Implemented check API https://moodledev.io/docs/apis/subsystems/check
- Created admin setting which takes in a check class and displays it nicely. (Note this will eventually be integrated a bit nicer likely with ajax in core https://tracker.moodle.org/browse/MDL-67898)
- This check now only runs when you are viewing the full tree (i.e. not searching) and when you are on the elasticsearch config page. Since it can take up to the timeout (5 seconds default) - we don't want this running when viewing other pages, etc...

## Screenshots

See https://github.com/catalyst/moodle-search_elastic/pull/108#discussion_r1325128349


