### PR TITLE
Enable HTTP BasicAuth components for Elasticsearch and Tika URLs

### DIFF
--- a/classes/admin_setting_configurl.php
+++ b/classes/admin_setting_configurl.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Elasticsearch engine.
+ *
+ * Provides an interface between Moodles Global search functionality
+ * and the Elasticsearch (https://www.elastic.co/products/elasticsearch)
+ * search engine.
+ *
+ * Elasticsearch presents a REST Webservice API that we communicate with
+ * via Curl.
+ *
+ * @package     search_elastic
+ * @copyright   Matt Porritt <mattp@catalyst-au.net>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace search_elastic;
+
+/**
+ * Elasticsearch settings.
+ *
+ * @package     search_elastic
+ * @copyright   2023 Lars Thoms <lars@thoms.io>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class admin_setting_configurl extends \admin_setting_configtext {
+
+    /**
+     * Unlike `PARAM_URL`, HTTP BasicAuth components are allowed.
+     * It must also be an HTTP scheme, and port or path specifications
+     * are not allowed.
+     *
+     * @param $data
+     * @return \lang_string|mixed|string|true
+     * @throws \coding_exception
+     */
+    public function validate($data) {
+        if (self::validateURL($data)) {
+            return true;
+        } else {
+            return get_string('validateerror', 'admin');
+        }
+    }
+
+    static public function validateURL($data) {
+        global $CFG;
+
+        $data = (string)fix_utf8($data);
+        include_once($CFG->dirroot . '/lib/validateurlsyntax.php');
+        return (!empty($data) && validateUrlSyntax($data, 's+H?S?F-E-u?P?a+I?p-f-q-r-'));
+    }
+}

--- a/classes/enrich/text/tika.php
+++ b/classes/enrich/text/tika.php
@@ -195,7 +195,7 @@ class tika extends base_enrich {
      */
     public static function form_definition_extra($form, $mform, $customdata, $config) {
         $mform->addElement('text', 'tikahostname',  get_string ('tikahostname', 'search_elastic'));
-        $mform->setType('tikahostname', PARAM_URL);
+        $mform->setType('tikahostname', PARAM_TEXT);
         $mform->addHelpButton('tikahostname', 'tikahostname', 'search_elastic');
         self::set_default('tikahostname', 'http://127.0.0.1', $mform, $customdata, $config);
 

--- a/classes/enrich_form.php
+++ b/classes/enrich_form.php
@@ -199,4 +199,22 @@ class enrich_form extends \moodleform {
         $this->add_action_buttons();
     }
 
+    /**
+     * Unlike `PARAM_URL`, HTTP BasicAuth components are allowed.
+     * It must also be an HTTP scheme, and port or path specifications
+     * are not allowed.
+     *
+     * @param $data
+     * @param $files
+     * @return array
+     */
+    function validation($data, $files)
+    {
+        $errors = parent::validation($data, $files);
+        if (!admin_setting_configurl::validateURL($data['tikahostname'])) {
+            $errors['tikahostname'] = 'Error - incorrect URL';
+        }
+        return $errors;
+    }
+
 }

--- a/settings.php
+++ b/settings.php
@@ -23,6 +23,7 @@
  */
 
 use search_elastic\admin_setting_check;
+use search_elastic\admin_setting_configurl;
 use search_elastic\check\server_ready_check;
 
 defined('MOODLE_INTERNAL') || die();
@@ -40,8 +41,8 @@ if ($hassiteconfig) {
             new server_ready_check()));
     }
 
-    $settings->add(new admin_setting_configtext('search_elastic/hostname', get_string ('hostname', 'search_elastic'),
-        get_string ('hostname_help', 'search_elastic'), '', PARAM_URL));
+    $settings->add(new admin_setting_configurl('search_elastic/hostname', get_string ('hostname', 'search_elastic'),
+        get_string ('hostname_help', 'search_elastic'), ''));
 
     $settings->add(new admin_setting_configtext('search_elastic/port', get_string ('port', 'search_elastic'),
         get_string ('port_help', 'search_elastic'), 9200, PARAM_INT));


### PR DESCRIPTION
The validator `PARAM_URL` does not permit the use of usernames and passwords in URLs for authenticating against an external service.