### PR TITLE
Added property check on Tika responses

### DIFF
--- a/classes/enrich/text/tika.php
+++ b/classes/enrich/text/tika.php
@@ -156,10 +156,12 @@ class tika extends base_enrich {
                 if ($jsoncontent = json_decode($response->getBody())) {
                     // Loop through embedded documents.
                     foreach ($jsoncontent as $datacontent) {
-                        $content = $datacontent->{"X-TIKA:content"};
-                        preg_match("/<body.*\/body>/s", $content, $bodytext);
-                        if ($bodytext) {
-                            $extractedtext .= strip_tags($bodytext[0]);
+                        if (property_exists($datacontent, "X-TIKA:content")) {
+                            $content = $datacontent->{"X-TIKA:content"};
+                            preg_match("/<body.*\/body>/s", $content, $bodytext);
+                            if ($bodytext) {
+                                $extractedtext .= strip_tags($bodytext[0]);
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
Occasionally, Apache Tika responses may not include an `X-TIKA:content` property, causing the following error to be thrown: `PHP Warning:  Undefined property: stdClass::$X-TIKA:content` on line 159 in `search/engine/elastic/classes/enrich/text/tika.php`.