### PR TITLE
Fix docoffset in results processing

### DIFF
--- a/classes/document.php
+++ b/classes/document.php
@@ -111,6 +111,13 @@ class document extends \core_search\document {
             ),
     );
 
+    /**
+     * @var mixed $config Search plugin configuration.
+     */
+    protected mixed $config;
+
+    /** @var bool Is file indexing enabled? */
+    protected bool $fileindexing;
 
     /**
      * Constructor for document class.

--- a/classes/engine.php
+++ b/classes/engine.php
@@ -830,10 +830,10 @@ class engine extends \core_search\engine {
                     $totalhits = $results->hits->total;
                 }
                 $docs = array_merge($docs, $this->compile_results($results, $limit));
-                $docoffest = count($docs);
+                $docoffest += count($results->hits->hits);
             }
 
-        } while ((count($docs) < $limit) && ($totalhits > \search_elastic\query::MAX_RESULTS));
+        } while ((count($docs) < $limit) && ($totalhits > \search_elastic\query::MAX_RESULTS) && ($docoffest < $totalhits));
 
         // TODO: handle negative cases and errors.
         return $docs;

--- a/classes/enrich/base/base_enrich.php
+++ b/classes/enrich/base/base_enrich.php
@@ -34,6 +34,11 @@ namespace search_elastic\enrich\base;
 abstract class base_enrich {
 
     /**
+     * @var mixed $config Search plugin configuration.
+     */
+    protected mixed $config;
+
+    /**
      * The constructor for the class, will be overwritten in most cases.
      *
      * @param mixed $config Search plugin configuration.

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024112000;
-$plugin->release   = '4.2.5 (Build: 20231222)'; // Build same as version.
+$plugin->version   = 2025051400;
+$plugin->release   = '4.2.6 (Build: 20250514)'; // Build same as version.
 $plugin->requires  = 2023042405;
 $plugin->component = 'search_elastic';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
This ensures $docoffset is incremented by the total count of hits returned from the search engine, not just those that passed permission checks, so the same documents are not processed multiple times.