### PR TITLE
declare properties in classes php 8.3 fix

### DIFF
--- a/classes/enrich/image/rekognition.php
+++ b/classes/enrich/image/rekognition.php
@@ -36,6 +36,13 @@ use search_elastic\aws_helper;
  */
 class rekognition extends base_enrich {
 
+    public $config;
+    public $rekregion;
+    public $rekkey;
+    public $reksecret;
+    public $maxlabels;
+    public $minconfidence;
+
     /**
      * Array of file mimetypes that enrichment class supports
      * processing of / extracting data from.

--- a/classes/enrich/image/rekognition.php
+++ b/classes/enrich/image/rekognition.php
@@ -43,27 +43,27 @@ class rekognition extends base_enrich {
     public mixed $config;
     /**
      * Summary of rekregion
-     * @var 
+     * @var
      */
     public $rekregion;
     /**
      * Summary of rekkey
-     * @var 
+     * @var
      */
     public $rekkey;
     /**
      * Summary of reksecret
-     * @var 
+     * @var
      */
     public $reksecret;
     /**
      * Summary of maxlabels
-     * @var 
+     * @var
      */
     public $maxlabels;
     /**
      * Summary of minconfidence
-     * @var 
+     * @var
      */
     public $minconfidence;
 

--- a/classes/enrich/image/rekognition.php
+++ b/classes/enrich/image/rekognition.php
@@ -36,11 +36,35 @@ use search_elastic\aws_helper;
  */
 class rekognition extends base_enrich {
 
-    public $config;
+    /**
+     * Summary of config
+     * @var mixed
+     */
+    public mixed $config;
+    /**
+     * Summary of rekregion
+     * @var 
+     */
     public $rekregion;
+    /**
+     * Summary of rekkey
+     * @var 
+     */
     public $rekkey;
+    /**
+     * Summary of reksecret
+     * @var 
+     */
     public $reksecret;
+    /**
+     * Summary of maxlabels
+     * @var 
+     */
     public $maxlabels;
+    /**
+     * Summary of minconfidence
+     * @var 
+     */
     public $minconfidence;
 
     /**

--- a/classes/enrich/text/tika.php
+++ b/classes/enrich/text/tika.php
@@ -67,8 +67,20 @@ class tika extends base_enrich {
             'application/vnd.oasis.opendocument.presentation',
             'application/epub+zip'
     );
-    public $config;
+    /**
+     * Summary of config
+     * @var 
+     */
+    public mixed $config;
+    /**
+     * Summary of tikaport
+     * @var 
+     */
     public $tikaport;
+    /**
+     * Summary of tikahostname
+     * @var 
+     */
     public $tikahostname;
 
     /**

--- a/classes/enrich/text/tika.php
+++ b/classes/enrich/text/tika.php
@@ -67,6 +67,9 @@ class tika extends base_enrich {
             'application/vnd.oasis.opendocument.presentation',
             'application/epub+zip'
     );
+    public $config;
+    public $tikaport;
+    public $tikahostname;
 
     /**
      * The constructor for the class, will be overwritten in most cases.

--- a/classes/enrich/text/tika.php
+++ b/classes/enrich/text/tika.php
@@ -69,17 +69,17 @@ class tika extends base_enrich {
     );
     /**
      * Summary of config
-     * @var 
+     * @var
      */
     public mixed $config;
     /**
      * Summary of tikaport
-     * @var 
+     * @var
      */
     public $tikaport;
     /**
      * Summary of tikahostname
-     * @var 
+     * @var
      */
     public $tikahostname;
 

--- a/tests/document_test.php
+++ b/tests/document_test.php
@@ -40,6 +40,8 @@ require_once($CFG->dirroot . '/search/engine/elastic/tests/fixtures/aws_rekognit
  */
 class document_test extends \advanced_testcase {
 
+    private $generator;
+
     public function setUp(): void {
         $this->resetAfterTest();
         new \search_elastic\engine();

--- a/tests/document_test.php
+++ b/tests/document_test.php
@@ -42,7 +42,7 @@ class document_test extends \advanced_testcase {
 
     /**
      * Summary of generator
-     * @var 
+     * @var
      */
     private $generator;
 

--- a/tests/document_test.php
+++ b/tests/document_test.php
@@ -40,6 +40,10 @@ require_once($CFG->dirroot . '/search/engine/elastic/tests/fixtures/aws_rekognit
  */
 class document_test extends \advanced_testcase {
 
+    /**
+     * Summary of generator
+     * @var 
+     */
     private $generator;
 
     public function setUp(): void {

--- a/tests/fixtures/mock_search_area.php
+++ b/tests/fixtures/mock_search_area.php
@@ -60,6 +60,7 @@ class mock_boost_area extends \core_mocksearch\search\mock_search_area {
 
     /**
      * A helper function that will turn a record into 'data array', for use with document building.
+     * @param $record
      */
     public function convert_record_to_doc_array($record) {
         $docdata = (array)unserialize($record->info);


### PR DESCRIPTION
PHP 8.3 has deprecated using undeclared property's in classes, throwing warnings in logs for unit tests etc. 

Just declaring all the previously undeclared properties to stop the warnings. Have not added comments about them because I don't know that they all are or how to document them properly, just removing the warnings for now