### PR TITLE
Add error reporting and retry mechanism for indexing failures

### DIFF
--- a/classes/document.php
+++ b/classes/document.php
@@ -24,6 +24,8 @@
 
 namespace search_elastic;
 
+use search_elastic\local\service\error_service;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/course/lib.php');
@@ -232,7 +234,12 @@ class document extends \core_search\document {
         foreach ($processors as $processor) {  // Loop thorugh processors to see if they support this files mimetype.
             $proc = new $processor($this->config);
             if ($proc->can_analyze($file)) {  // Sequentially process the file apppending results to $filetext.
-                $filetext .= $proc->analyze_file($file);
+                try {
+                    $filetext .= $proc->analyze_file($file);
+                } catch (\Throwable $e) {
+                    error_service::record_tika_error($file, $e->getMessage(), $this->data['id']);
+                    $filetext .= '';
+                }
             }
         }
 

--- a/classes/engine.php
+++ b/classes/engine.php
@@ -31,6 +31,8 @@
 
 namespace search_elastic;
 
+use search_elastic\local\service\error_service;
+
 /**
  * Elasticsearch engine.
  *
@@ -640,21 +642,48 @@ class engine extends \core_search\engine {
             // If there are errors we need to iterate through he response and count how many.
             if ($response->getStatusCode() == 413) {
                 // TODO: add handling to retry sending payload one record at a time.
-                debugging ( get_string ( 'addfail', 'search_elastic' ) . ' Request Entity Too Large', DEBUG_DEVELOPER );
+                $message = get_string ('addfail', 'search_elastic') . ' Request Entity Too Large';
+                error_service::record_batch_error($message, $this->payload);
                 $numdocsignored = $this->count;
-
             } else if ($response->getStatusCode() >= 300) {
-                debugging ( get_string ( 'addfail', 'search_elastic' ) .
-                        ' Error Code: ' . $response->getStatusCode(), DEBUG_DEVELOPER );
+                $message = get_string('addfail', 'search_elastic') . ' Error Code: ' . $response->getStatusCode();
+                error_service::record_batch_error($message, $this->payload);
                 $numdocsignored = $this->count;
 
-            } else if ($responsebody->errors) {
-                foreach ($responsebody->items as $item) {
-                    if ($item->index->status >= 300) {
-                        debugging ( get_string ( 'addfail', 'search_elastic' ) .
-                                ' Error Type: ' . $item->index->error->type .
-                                ' Error Reason: ' . $item->index->error->reason, DEBUG_DEVELOPER );
-                        $numdocsignored ++;
+            } else if (isset($responsebody->errors) && $responsebody->errors) {
+                $payloaddocs = $this->parse_payload_documents();
+
+                if (isset($responsebody->items) && is_array($responsebody->items)) {
+                    foreach ($responsebody->items as $responseindex => $item) {
+                        if (isset($item->index->status) && $item->index->status >= 300) {
+                            $errortype = $item->index->error->type ?? 'unknown';
+                            $errorreason = $item->index->error->reason ?? 'unknown';
+
+                            $message = get_string('addfail', 'search_elastic') .
+                                    ' Error Type: ' . $errortype .
+                                    ' Error Reason: ' . $errorreason;
+
+                            // Get corresponding document data using the same index.
+                            $docdata = null;
+                            if (isset($payloaddocs[$responseindex]) && is_array($payloaddocs[$responseindex])) {
+                                $candidatedoc = $payloaddocs[$responseindex];
+
+                                // Verify document ID matches to ensure we have the right document.
+                                $expectedid = $item->index->_id ?? null;
+                                $parsedid = $candidatedoc['id'] ?? null;
+
+                                if ($expectedid && $parsedid && $expectedid === $parsedid) {
+                                    $docdata = $candidatedoc;
+                                } else {
+                                    // Log mismatch for debugging but continue with error recording.
+                                    debugging('Document ID mismatch at index ' . $responseindex . ': expected ' .
+                                        $expectedid . ', got ' . $parsedid, DEBUG_DEVELOPER);
+                                }
+                            }
+
+                            error_service::record_document_error($message, $docdata);
+                            $numdocsignored++;
+                        }
                     }
                 }
             }
@@ -670,6 +699,85 @@ class engine extends \core_search\engine {
         }
 
         return $numdocsignored;
+    }
+
+    /**
+     * Parse the payload to extract document data with contextid.
+     *
+     * @return array Array of document data indexed by position.
+     */
+    private function parse_payload_documents(): array {
+        $documents = [];
+
+        if (empty($this->payload)) {
+            return $documents;
+        }
+
+        $lines = explode("\n", trim($this->payload));
+
+        // Process pair of lines (metadata and document data).
+        $docindex = 0;
+        for ($i = 0; $i < count($lines); $i += 2) {
+
+            // Always increment docindex for each attempted document pair,
+            // regardless of whether lines exist or parsing succeeds.
+            $documents[$docindex] = null;
+
+            if (isset($lines[$i]) && isset($lines[$i + 1])) {
+                $metadata = json_decode($lines[$i], true);
+                $docdata = json_decode($lines[$i + 1], true);
+                if ($metadata && $docdata) {
+                    $documents[$docindex] = [
+                        'metadata' => $metadata,
+                        'id' => $docdata['id'] ?? 'unknown',
+                        'contextid' => $docdata['contextid'] ?? \context_system::instance(),
+                        'areaid' => $docdata['areaid'] ?? 'unknown',
+                        'itemid' => $docdata['itemid'] ?? 0,
+                        'modified' => $docdata['modified'] ?? null,
+                    ];
+                }
+            }
+
+            $docindex++;
+        }
+
+        return $documents;
+    }
+
+
+    /**
+     * Index a single file document.
+     *
+     * @param array $filedocdata
+     * @return bool
+     */
+    public function index_single_file_document($filedocdata): bool {
+        try {
+            $url = $this->get_url();
+            $luceneversion = $this->get_es_lucene_version();
+
+            $docprefix = '_';
+            if ($luceneversion < 8) {
+                $docprefix = '';
+            }
+
+            $docurl = $url . '/'. $this->config->index . '/' . $docprefix . 'doc/' . $filedocdata['id'];
+            $jsondoc = json_encode($filedocdata);
+
+            $client = new \search_elastic\esrequest();
+            $response = $client->post($docurl, $jsondoc);
+            $responsecode = $response->getStatusCode();
+
+            if ($responsecode !== 201 && $responsecode !== 200) {
+                debugging('Failed to index file document: ' . $response->getBody(), DEBUG_DEVELOPER);
+                return false;
+            }
+
+            return true;
+        } catch (\Exception $e) {
+            debugging('Exception indexing file document: ' . $e->getMessage(), DEBUG_DEVELOPER);
+            return false;
+        }
     }
 
     /**
@@ -698,7 +806,10 @@ class engine extends \core_search\engine {
         $responsecode = $response->getStatusCode();
 
         if ($responsecode !== 201 && $responsecode !== 200) {
-            debugging(get_string('addfail', 'search_elastic') . $response->getBody(), DEBUG_DEVELOPER);
+            $responsebody = json_decode($response->getBody());
+            error_service::record_document_error(get_string('addfail', 'search_elastic') .
+                    ' Error Type: ' . $responsebody->error->type .
+                    ' Error Reason: ' . $responsebody->error->reason, $docdata);
             return false;
         }
 

--- a/classes/enrich/text/tika.php
+++ b/classes/enrich/text/tika.php
@@ -24,7 +24,9 @@
 
 namespace search_elastic\enrich\text;
 
+use Exception;
 use search_elastic\enrich\base\base_enrich;
+use Throwable;
 
 /**
  * Extract text from files using Tika.
@@ -165,23 +167,39 @@ class tika extends base_enrich {
         $url = $hostname . ':'. $port . '/rmeta/form'; // Support embedded documents.
         $filesize = $file->get_filesize();
 
-        if ($filesize <= $this->config->tikasendsize) {
-            $response = $client->postfile($url, $file);
-            if ($response->getStatusCode() == 200) {
-                if ($jsoncontent = json_decode($response->getBody())) {
-                    // Loop through embedded documents.
-                    foreach ($jsoncontent as $datacontent) {
-                        $content = $datacontent->{"X-TIKA:content"};
-                        preg_match("/<body.*\/body>/s", $content, $bodytext);
-                        if ($bodytext) {
-                            $extractedtext .= strip_tags($bodytext[0]);
-                        }
-                    }
-                } else {
-                    $extractedtext = (string) $response->getBody();
-                }
-            }
+        if ($filesize > $this->config->tikasendsize) {
+            $message = 'File too large for Tika extraction. Size: ' . $filesize . ' bytes, limit: ' .
+                $this->config->tikasendsize . ' bytes';
+            throw new Exception($message);
         }
+
+        $handle = $file->get_content_file_handle();
+        if (!$handle) {
+            throw new Exception('File not found: ' . $file->get_filename());
+        }
+
+        try {
+            $response = $client->postfile($url, $file);
+            if ($response->getStatusCode() !== 200) {
+                throw new Exception('Tika returned non-200 status code ' . $response->getStatusCode());
+            }
+
+            if ($jsoncontent = json_decode($response->getBody())) {
+                // Loop through embedded documents.
+                foreach ($jsoncontent as $datacontent) {
+                    $content = $datacontent->{"X-TIKA:content"};
+                    preg_match("/<body.*\/body>/s", $content, $bodytext);
+                    if ($bodytext) {
+                        $extractedtext .= strip_tags($bodytext[0]);
+                    }
+                }
+            } else {
+                $extractedtext = (string) $response->getBody();
+            }
+        } catch (Throwable $e) {
+            throw new Exception('Tika extraction failed: ' . $e->getMessage());
+        }
+
         return $extractedtext;
     }
 

--- a/classes/error_action_handler.php
+++ b/classes/error_action_handler.php
@@ -1,0 +1,217 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic;
+
+use core\notification;
+use core\task\manager;
+use dml_missing_record_exception;
+use Exception;
+use moodle_url;
+use search_elastic\local\model\error;
+use search_elastic\local\service\error_service;
+use search_elastic\task\retry_errors_task;
+
+/**
+ * Handles error-related actions from the admin interface.
+ *
+ * @package     search_elastic
+ * @copyright   2025 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class error_action_handler {
+
+    /** Delete a single error record from database. */
+    const ACTION_DELETE_SINGLE = 'delete_single';
+
+    /** Delete all error records that have obsolete status. */
+    const ACTION_DELETE_ALL_OBSOLETE = 'delete_all_obsolete';
+
+    /** Retry indexing for a single error record. */
+    const ACTION_RETRY_SINGLE = 'retry_single';
+
+    /** Retry all error records that have failed status. */
+    const ACTION_RETRY_ALL_FAILED = 'retry_all_failed';
+
+    /** File size threshold for spawning adhoc tasks (1 MB). */
+    const ADHOC_TASK_FILE_THRESHOLD = 1000000;
+
+    /**
+     * Handle error-related actions.
+     *
+     * @param string $action The action to perform
+     * @param int $errorid The ID of the error (for single retry operations)
+     * @param moodle_url $pageurl The page URL to redirect to
+     * @param bool $confirm Whether the action was confirmed
+     */
+    public static function handle_action(string $action, int $errorid, moodle_url $pageurl, bool $confirm = false): void {
+        // Redirect if no confirmation.
+        if (!$confirm) {
+            redirect($pageurl);
+        }
+
+        switch ($action) {
+            case self::ACTION_DELETE_SINGLE:
+                self::handle_delete_single($errorid, $pageurl);
+                break;
+            case self::ACTION_DELETE_ALL_OBSOLETE:
+                self::handle_delete_all_obsolete($pageurl, $confirm);
+                break;
+            case self::ACTION_RETRY_SINGLE:
+                self::handle_retry_single($errorid, $pageurl);
+                break;
+            case self::ACTION_RETRY_ALL_FAILED:
+            default:
+                self::handle_retry_all_failed($pageurl, $confirm);
+        }
+    }
+
+    /**
+     * This will delete a given error record from database.
+     *
+     * @param int $errorid
+     * @param moodle_url $pageurl The page URL to redirect to
+     */
+    private static function handle_delete_single(int $errorid, moodle_url $pageurl): void {
+        if (!$errorid) {
+            notification::error(get_string('invaliderrorid', 'search_elastic'));
+            redirect($pageurl);
+        }
+
+        try {
+            $error = new error($errorid);
+            $error->delete();
+            notification::success(get_string('deletedsuccessfully', 'search_elastic', $errorid));
+            redirect($pageurl);
+        } catch (dml_missing_record_exception $e) {
+            notification::warning(get_string('erroridnotfound', 'search_elastic', $errorid));
+            redirect($pageurl);
+        }
+    }
+
+    /**
+     * This will delete all error records that have obsolete status.
+     *
+     * @param moodle_url $pageurl The page URL to redirect to
+     */
+    private static function handle_delete_all_obsolete(moodle_url $pageurl): void {
+        global $DB;
+
+        try {
+            $obsoletecount = error_service::get_error_count_by_status(error::STATUS_OBSOLETE);
+            $deleted = $DB->delete_records('search_elastic_errors', ['status' => error::STATUS_OBSOLETE]);
+            if ($deleted) {
+                notification::success(get_string('deletedobsoleteerrors', 'search_elastic', $obsoletecount));
+            }
+        } catch (Exception $e) {
+            notification::error(get_string('deleteobsoleteexception', 'search_elastic', $e->getMessage()));
+        }
+
+        redirect($pageurl);
+    }
+
+    /**
+     * This will retry all error records that have failed status.
+     *
+     * @param moodle_url $pageurl The page URL to redirect to
+     */
+    private static function handle_retry_all_failed(moodle_url $pageurl): void {
+        global $USER;
+
+        $task = new retry_errors_task();
+        $task->set_custom_data([
+            'operation' => self::ACTION_RETRY_ALL_FAILED,
+            'userid' => $USER->id,
+        ]);
+
+        $task->set_component('search_elastic');
+        manager::queue_adhoc_task($task);
+        notification::info(get_string('retryallqueued', 'search_elastic'));
+
+        redirect($pageurl);
+    }
+
+    /**
+     * This will retry indexing for a given error record.
+     *
+     * @param int $errorid
+     * @param moodle_url $pageurl The page URL to redirect to
+     */
+    private static function handle_retry_single(int $errorid, moodle_url $pageurl): void {
+        global $USER;
+
+        if (!$errorid) {
+            notification::error(get_string('invaliderrorid', 'search_elastic'));
+            redirect($pageurl);
+        }
+
+        try {
+            $error = new error($errorid);
+            if (!$error->can_retry()) {
+                notification::error(get_string('exceededmaxretries', 'search_elastic'));
+                redirect($pageurl);
+            }
+
+            if (self::should_spawn_adhoc_task($error)) {
+                $task = new retry_errors_task();
+                $task->set_custom_data([
+                    'operation' => self::ACTION_RETRY_SINGLE,
+                    'errorid' => $errorid,
+                    'userid' => $USER->id,
+                ]);
+
+                $task->set_component('search_elastic');
+                manager::queue_adhoc_task($task);
+                notification::info(get_string('retrysingleadhoc', 'search_elastic'));
+                redirect($pageurl);
+            }
+
+            $result = error_service::retry_error($errorid);
+            $result['success'] ? notification::success($result['message']) : notification::error($result['message']);
+        } catch (dml_missing_record_exception $e) {
+            notification::warning(get_string('erroridnotfound', 'search_elastic', $errorid));
+        }
+
+        redirect($pageurl);
+    }
+
+    /**
+     * Determine if an adhoc task should be spawned for retrying an error.
+     *
+     * For Tika errors, files with size greater than 1 MB are processed via adhoc task.
+     * For Indexing errors, documents with files are processed via adhoc task.
+     *
+     * @param error $error
+     * @return bool
+     */
+    private static function should_spawn_adhoc_task(error $error): bool {
+        global $DB;
+
+        if ($error->get('errortype') == error::TYPE_TIKA) {
+            $fileid = (int)($error->get('docid'));
+            if (!$fileid) {
+                return false;
+            }
+
+            $filesize = $DB->get_field('files', 'filesize', ['id' => $fileid]);
+            if ($filesize && (int)$filesize > self::ADHOC_TASK_FILE_THRESHOLD) {
+                return true;
+            }
+        }
+
+        return error_service::error_has_indexable_files($error);
+    }
+}

--- a/classes/local/model/error.php
+++ b/classes/local/model/error.php
@@ -1,0 +1,162 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic\local\model;
+
+use core\persistent;
+
+/**
+ * Error persistent model for Elasticsearch indexing errors.
+ *
+ * @package    search_elastic
+ * @author     Trisha Milan <trishamilan@catalyst-au.net>
+ * @copyright  2025 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class error extends persistent {
+
+    /** @var string The table name. */
+    const TABLE = 'search_elastic_errors';
+
+    /** Error type for indexing. */
+    const TYPE_INDEXING = 'indexing';
+
+    /** Error type for Tika-related errors. */
+    const TYPE_TIKA = 'tika';
+
+    /** For errors currently being processed. */
+    const STATUS_RETRYING = 'retrying';
+
+    /** Exceeded the max retry limit. */
+    const STATUS_FAILED = 'failed';
+
+    /** Content no longer exists. */
+    const STATUS_OBSOLETE = 'obsolete';
+
+    /**
+     * Return the definition of the properties of this model.
+     *
+     * @return array
+     */
+    protected static function define_properties() {
+        return [
+            'docid' => [
+                'type' => PARAM_TEXT,
+                'null' => NULL_NOT_ALLOWED,
+            ],
+            'itemid' => [
+                'type' => PARAM_INT,
+                'null' => NULL_NOT_ALLOWED,
+            ],
+            'contextid' => [
+                'type' => PARAM_INT,
+                'null' => NULL_ALLOWED,
+                'default' => null,
+            ],
+            'areaid' => [
+                'type' => PARAM_TEXT,
+                'null' => NULL_NOT_ALLOWED,
+            ],
+            'errortype' => [
+                'type' => PARAM_ALPHA,
+                'null' => NULL_NOT_ALLOWED,
+                'choices' => [
+                    self::TYPE_INDEXING,
+                    self::TYPE_TIKA,
+                ],
+            ],
+            'errormessage' => [
+                'type' => PARAM_TEXT,
+                'null' => NULL_NOT_ALLOWED,
+            ],
+            'retrycount' => [
+                'type' => PARAM_INT,
+                'null' => NULL_NOT_ALLOWED,
+                'default' => 0,
+            ],
+            'status' => [
+                'type' => PARAM_TEXT,
+                'null' => NULL_NOT_ALLOWED,
+                'default' => self::STATUS_FAILED,
+                'choices' => [
+                    self::STATUS_RETRYING,
+                    self::STATUS_FAILED,
+                    self::STATUS_OBSOLETE,
+                ],
+            ],
+            'timecreated' => [
+                'type' => PARAM_INT,
+                'null' => NULL_NOT_ALLOWED,
+            ],
+            'timemodified' => [
+                'type' => PARAM_INT,
+                'null' => NULL_NOT_ALLOWED,
+            ],
+            'contentmodified' => [
+                'type' => PARAM_INT,
+                'null' => NULL_ALLOWED,
+                'default' => null,
+            ],
+            'parentid' => [
+                'type' => PARAM_TEXT,
+                'null' => NULL_ALLOWED,
+                'default' => null,
+            ],
+        ];
+    }
+
+    /**
+     * Mark this error as failed.
+     */
+    public function mark_failed() {
+        $this->set('status', self::STATUS_FAILED);
+        $this->save();
+    }
+
+    /**
+     * Mark this error as retrying.
+     */
+    public function mark_retrying() {
+        $this->set('status', self::STATUS_RETRYING);
+        $this->save();
+    }
+
+    /**
+     * Mark error as obsolete (content no longer exists).
+     */
+    public function mark_obsolete() {
+        $this->set('status', self::STATUS_OBSOLETE);
+        $this->save();
+    }
+
+    /**
+     * Increment the retry count.
+     */
+    public function increment_retry() {
+        $newcount = $this->get('retrycount') + 1;
+        $this->set('retrycount', $newcount);
+        $this->save();
+    }
+
+    /**
+     * Check if this error can be retried.
+     *
+     * @return bool
+     */
+    public function can_retry(): bool {
+        return $this->get('status') !== self::STATUS_OBSOLETE;
+    }
+}

--- a/classes/local/service/error_service.php
+++ b/classes/local/service/error_service.php
@@ -1,0 +1,523 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic\local\service;
+
+use context;
+use core_search\manager;
+use Exception;
+use search_elastic\engine;
+use search_elastic\enrich\text\tika;
+use search_elastic\local\model\error;
+use stdClass;
+use stored_file;
+use Throwable;
+
+/**
+ * Service class for managing Elasticsearch errors.
+ *
+ * @package    search_elastic
+ * @author     Trisha Milan <trishamilan@catalyst-au.net>
+ * @copyright  2025 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class error_service {
+
+    /**
+     * Retry a specific error by ID.
+     *
+     * @param  int $id The error ID to retry
+     * @return array
+     */
+    public static function retry_error(int $id): array {
+        try {
+            $error = new error($id);
+
+            if (!$error->can_retry()) {
+                return ['success' => false, 'message' => get_string('exceededmaxretries', 'search_elastic')];
+            }
+
+            $error->mark_retrying();
+            $result = self::execute_retry($error);
+
+            // Reset the instance to the values in the database.
+            $error->read();
+
+            if ($result['success']) {
+                // Delete the error record once it's successfully re-indexed.
+                $error->delete();
+            } else {
+                $error->increment_retry();
+            }
+
+            return $result;
+        } catch (\dml_missing_record_exception $e) {
+            return ['success' => false, 'message' => get_string('erroridnotfound', 'search_elastic', $id)];
+        } catch (Exception $e) {
+            $error->increment_retry();
+            return ['success' => false, 'message' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * Saves an error to the database, creating new record or updating an existing one.
+     *
+     * @param string $documentid Document ID that failed
+     * @param int $itemid Item ID
+     * @param int|null $contextid Context ID
+     * @param string $areaid Search area ID
+     * @param string $errortype Type of error (indexing, tika)
+     * @param string $errormessage Error message
+     * @param int|null $contentmodified Content modification timestamp
+     * @param string $parentid The parent ID used for file documents
+     */
+    public static function save_error($documentid, $itemid, $contextid, $areaid, $errortype, $errormessage,
+            $contentmodified = null, $parentid = null): void {
+        global $DB;
+
+        $now = time();
+
+        $select = $DB->sql_compare_text('docid') . ' = :docid AND errortype = :errortype';
+        $params = [
+            'docid' => $documentid,
+            'errortype' => $errortype,
+        ];
+
+        $existing = error::get_records_select($select, $params);
+        if ($existing) {
+            // Update existing error (get the first one if multiple).
+            $error = reset($existing);
+            $error->set('errortype', $errortype);
+            $error->set('errormessage', $errormessage);
+            $error->set('status', error::STATUS_FAILED);
+            $error->set('timemodified', $now);
+            $error->set('contentmodified', $contentmodified);
+            $error->save();
+
+        } else {
+            // Create new error.
+            $error = new error();
+            $error->set('docid', $documentid);
+            $error->set('itemid', $itemid);
+            $error->set('areaid', $areaid);
+            $error->set('errortype', $errortype);
+            $error->set('errormessage', $errormessage);
+            $error->set('retrycount', 0);
+            $error->set('status', error::STATUS_FAILED);
+            $error->set('timecreated', $now);
+            $error->set('timemodified', $now);
+            $error->set('contentmodified', $contentmodified);
+            $error->set('contextid', $contextid);
+            $error->set('parentid', $parentid);
+            $error->create();
+        }
+    }
+
+    /**
+     * Returns count of errors by status.
+     *
+     * @param  string $status Error status
+     * @return int
+     */
+    public static function get_error_count_by_status($status): int {
+        return error::count_records(['status' => $status]);
+    }
+
+    /**
+     * Record a batch processing error by parsing the payload.
+     *
+     * @param  string $message Error message
+     * @param  string $payload The json payload that failed
+     * @param  int $debuglevel The level at which the debugging statement should show
+     */
+    public static function record_batch_error(string $message, string $payload, int $debuglevel = DEBUG_NORMAL): void {
+        $lines = explode("\n", trim($payload));
+        for ($i = 0; $i < count($lines); $i += 2) {
+            if (isset($lines[$i]) && isset($lines[$i + 1])) {
+                $meta = json_decode($lines[$i], true);
+                $doc = json_decode($lines[$i + 1], true);
+
+                if ($meta && $doc && isset($meta['index']['_id'])) {
+                    $docid = $meta['index']['_id'];
+                    $itemid = $doc['itemid'] ?? 0;
+                    $areaid = $doc['areaid'] ?? 'unknown';
+                    $contextid = $doc['contextid'] ?? 0;
+                    $modified = $doc['modified'] ?? null;
+
+                    debugging($message, $debuglevel);
+
+                    self::save_error($docid, $itemid, $contextid, $areaid, error::TYPE_INDEXING,
+                        $message . ' (Document: ' . $docid .')', $modified);
+                }
+            }
+        }
+    }
+
+    /**
+     * Record an individual document error from Elasticsearch response.
+     *
+     * @param  string $message Error message
+     * @param  array|null $docdata Array of document data
+     * @param  int $debuglevel The level at which the debugging statement should show
+     */
+    public static function record_document_error(string $message, ?array $docdata = null, int $debuglevel = DEBUG_NORMAL): void {
+        if (is_null($docdata) || !isset($docdata['id'])) {
+            return;
+        }
+
+        $documentinfo = self::extract_document_info($docdata);
+        self::save_error($documentinfo['docid'], $documentinfo['itemid'], $documentinfo['contextid'],
+            $documentinfo['areaid'], error::TYPE_INDEXING, $message, $documentinfo['modified']);
+
+        debugging($message, $debuglevel);
+    }
+
+    /**
+     * Record a Tika-related error.
+     *
+     * @param  stored_file $file The file that caused an error
+     * @param  string $message Error message
+     * @param  string|null $parentid The file document parent ID
+     * @param  int $debuglevel The level at which the debugging statement should show
+     */
+    public static function record_tika_error(stored_file $file, string $message, ?string $parentid = null,
+            int $debuglevel = DEBUG_DEVELOPER): void {
+        $areaid = self::get_file_areaid($file);
+
+        $errormessage = $message . ' (File: ' . $file->get_filename() . ', Size: ' . $file->get_filesize() . ' bytes' .
+            ', Component: ' . $file->get_component() . ', Filearea: ' . $areaid . ')';
+
+        $docid = $file->get_id();
+        self::save_error($docid, $file->get_itemid(), $file->get_contextid(), $areaid,
+            error::TYPE_TIKA, $errormessage, $file->get_timemodified(), $parentid);
+
+        debugging($errormessage, $debuglevel);
+    }
+
+    /**
+     * Extract document information from document data array.
+     *
+     * @param  array|null $docdata Document data array
+     * @return array Extracted document information
+     */
+    private static function extract_document_info(?array $docdata = null): array {
+        $info = [
+            'docid' => null,
+            'areaid' => 'unknown',
+            'itemid' => 0,
+            'contextid' => null,
+            'modified' => null,
+        ];
+
+        if ($docdata) {
+            $info['docid'] = $docdata['id'] ?? null;
+            $info['areaid'] = $docdata['areaid'] ?? $info['areaid'];
+            $info['itemid'] = $docdata['itemid'] ?? $info['itemid'];
+            $info['contextid'] = $docdata['contextid'] ?? $info['contextid'];
+            $info['modified'] = $docdata['modified'] ?? $info['modified'];
+        }
+
+        return $info;
+    }
+
+    /**
+     * Get search area ID for a file.
+     *
+     * @param  stored_file $file
+     * @return string
+     */
+    private static function get_file_areaid(stored_file $file): string {
+        $component = $file->get_component();
+        $filearea = $file->get_filearea();
+
+        $searchareas = manager::get_search_areas_list(true);
+        $corecomponent = 'core_' . $component;
+
+        foreach ($searchareas as $areaid => $searcharea) {
+            if (strpos($areaid, $component) === 0 || strpos($areaid, $corecomponent) === 0) {
+                if (method_exists($searcharea, 'get_search_fileareas')) {
+                    $fileareas = $searcharea->get_search_fileareas();
+                    if (in_array($filearea, $fileareas)) {
+                        return $areaid;
+                    }
+                }
+            }
+        }
+
+        return $component . '-' . $filearea;
+    }
+
+    /**
+     * Execute the actual retry logic based on error type.
+     *
+     * @param error $error Error instance
+     * @return array Result array with 'success' and 'message' keys
+     */
+    private static function execute_retry(error $error): array {
+        try {
+            $engine = new engine();
+            $searcharea = manager::get_search_area($error->get('areaid'));
+            if (!$searcharea) {
+                $error->mark_obsolete();
+                return ['success' => false, 'message' => get_string('searchareanotfound', 'search_elastic')];
+            }
+        } catch (Throwable $e) {
+            $error->mark_obsolete();
+            return ['success' => false, 'message' => get_string('searchareanotfound', 'search_elastic')];
+        }
+
+        switch ($error->get('errortype')) {
+            case error::TYPE_TIKA:
+                return self::retry_file_extraction_and_indexing($error, $searcharea, $engine);
+            case error::TYPE_INDEXING:
+            default:
+                return self::retry_failed_document_indexing($error, $searcharea, $engine);
+        }
+    }
+
+    /**
+     * Check if the document associated with an error has files that can be indexed.
+     *
+     * @param error $error Error instance
+     * @return bool True if the document has files available for indexing
+     */
+    public static function error_has_indexable_files($error): bool {
+        $searcharea = manager::get_search_area($error->get('areaid'));
+        if (!$searcharea) {
+            return false;
+        }
+
+        $context = context::instance_by_id($error->get('contextid'));
+        $record = self::get_record_for_context($searcharea, $context, $error->get('itemid'));
+        if (!$record) {
+            return false;
+        }
+
+        $document = $searcharea->get_document($record);
+        if (!$document) {
+            return false;
+        }
+
+        $searcharea->attach_files($document);
+        $files = $document->get_files();
+
+        return empty($files) ? false : true;
+    }
+
+    /**
+     * Retry a failed document indexing operation.
+     *
+     * @param error $error Error instance
+     * @param \core_search\base $searcharea Search area instance
+     * @param engine $engine Elasticsearch engine
+     * @return array Result array
+     */
+    private static function retry_failed_document_indexing($error, $searcharea, $engine) {
+        try {
+            $itemid = $error->get('itemid');
+            $context = context::instance_by_id($error->get('contextid'));
+
+            // Get the record from search area.
+            $record = self::get_record_for_context($searcharea, $context, $itemid);
+            if (!$record) {
+                $error->mark_obsolete();
+                return['success' => false, 'message' => 'Content no longer exists'];
+            }
+
+            // Let the search area convert the record to a document.
+            $document = $searcharea->get_document($record);
+            if (!$document) {
+                $error->mark_failed();
+                return ['success' => false, 'message' => 'Search area could not create document from record'];
+            }
+
+            // Index the parent document first.
+            $success = $engine->add_document($document, false);
+            if (!$success) {
+                $error->mark_failed();
+                return ['success' => false, 'message' => 'Failed to index document'];
+            }
+
+            // Check if we need to index files.
+            $indexfiles = $engine->file_indexing_enabled() && $searcharea->uses_file_indexing();
+            if (!$indexfiles) {
+                return ['success' => true, 'message' => 'Content reindexed successfully'];
+            }
+
+            // Index files individually.
+            $searcharea->attach_files($document);
+            $files = $document->get_files();
+            if (empty($files)) {
+                return ['success' => true, 'message' => 'Content reindexed successfully'];
+            }
+
+            $fileerrorcount = 0;
+
+            foreach ($files as $file) {
+                $filedocdata = $document->export_file_for_engine($file);
+                $success = $engine->index_single_file_document($filedocdata);
+                if (!$success) {
+                    $fileerrorcount++;
+                }
+            }
+
+            if ($fileerrorcount == 0) {
+                return ['success' => true, 'message' => 'Content reindexed successfully'];
+            }
+
+            $error->mark_failed();
+            return ['success' => false, 'message' => 'Failed to reindex content'];
+        } catch (Exception $e) {
+            return ['success' => false, 'message' => 'Exception during retry: ' . $e->getMessage()];
+        }
+    }
+
+    /**
+     * Get record for context and item ID.
+     *
+     * @param \core_search\base $searcharea Search area instance
+     * @param context $context Context instance
+     * @param int $itemid Item ID
+     * @return stdClass|null Record or null if not found
+     */
+    private static function get_record_for_context($searcharea, $context, $itemid): ?stdClass {
+        $recordset = $searcharea->get_document_recordset(0, $context);
+        if (!$recordset) {
+            return null;
+        }
+
+        $foundrecord = null;
+        foreach ($recordset as $record) {
+            if ($record->id == $itemid) {
+                $foundrecord = $record;
+                break;
+            }
+        }
+
+        $recordset->close();
+        return $foundrecord;
+    }
+
+    /**
+     * Retry a file content extraction and parent document re-indexing.
+     *
+     * This method takes a Tika processing error and attempts to re-extract the file content
+     * and re-index it with its parent document using the parentid reference.
+     *
+     * @param error $error Error instance
+     * @param \core_search\base $searcharea Search area instance
+     * @param engine $engine Elasticsearch engine
+     * @return array Result array
+     */
+    private static function retry_file_extraction_and_indexing($error, $searcharea, $engine): array {
+        if (!$error->get('docid')) {
+            return ['success' => false, 'message' => 'No file ID associated with Tika error'];
+        }
+
+        try {
+            $fs = get_file_storage();
+            // The docid for Tika errors should be the file ID.
+            $file = $fs->get_file_by_id($error->get('docid'));
+            // We should also check if the actual file exists.
+            $handle = $file->get_content_file_handle();
+            if (!$file || !$handle) {
+                $error->mark_obsolete();
+                return ['success' => false, 'message' => 'File no longer exists'];
+            }
+
+            // Get the record from search area.
+            $parentid = $error->get('parentid');
+            $parentidparts = explode('-', $parentid);
+            $parentitemid = isset($parentidparts[2]) ? (int)$parentidparts[2] : null;
+            $context = context::instance_by_id($error->get('contextid'));
+            $parentrecord = self::get_record_for_context($searcharea, $context, $parentitemid);
+            if (!$parentrecord) {
+                $error->mark_obsolete();
+                return['success' => false, 'message' => 'Content no longer exists'];
+            }
+
+            // Create the parent document.
+            $parentdocument = $searcharea->get_document($parentrecord);
+            if (!$parentdocument) {
+                $error->mark_failed();
+                return ['success' => false, 'message' => 'Failed to create parent document'];
+            }
+
+            // Try to extract file contents using Tika. The export_file_for_engine does not throw
+            // an exception if there is any issue with the file, so we try to validate the file
+            // here instead of just indexing a file with empty file text.
+            $extractedtext = self::extract_file_contents($file);
+            if ($extractedtext === false) {
+                $error->mark_failed();
+                return ['success' => false, 'message' => 'Tika extraction failed'];
+            }
+
+            $parentdocument->add_stored_file($file);
+
+            // Create a file-specific document for indexing.
+            $filedocdata = $parentdocument->export_file_for_engine($file);
+
+            // Index just this specific file document.
+            $success = $engine->index_single_file_document($filedocdata);
+
+            if ($success) {
+                return ['success' => true, 'message' => 'File content extracted and indexed successfully'];
+            } else {
+                $error->mark_failed();
+                return ['success' => false, 'message' => 'File extraction succeeded but indexing failed'];
+            }
+
+        } catch (Exception $e) {
+            return ['success' => false, 'message' => 'Exception during Tika retry: ' . $e->getMessage()];
+        }
+    }
+
+    /**
+     * Extract file contents using Tika.
+     *
+     * @param  stored_file $file File to extract.
+     * @return string Extracted text or false on failure
+     */
+    private static function extract_file_contents(stored_file $file) {
+        $config = get_config('search_elastic');
+
+        if (empty($config->tikahostname) || empty($config->tikaport)) {
+            debugging('Tika not configured for retry');
+            return false;
+        }
+
+        try {
+            $tikaprocessor = new tika($config);
+            $extractedtext = $tikaprocessor->analyze_file($file);
+
+            if ($extractedtext == false || $extractedtext == null) {
+                debugging('Tika returned false/null for file' . $file->get_filename());
+                return false;
+            }
+
+            $extractedtext = trim($extractedtext);
+            if (empty($extractedtext)) {
+                debugging('Tika returned empty text for file: ' . $file->get_filename());
+                return false;
+            }
+
+            return $extractedtext;
+        } catch (Exception $e) {
+            debugging('Exception during Tika extraction: ' . $e->getMessage(), DEBUG_DEVELOPER);
+            return false;
+        }
+    }
+}

--- a/classes/reportbuilder/local/entities/error.php
+++ b/classes/reportbuilder/local/entities/error.php
@@ -1,0 +1,345 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic\reportbuilder\local\entities;
+
+use core_search\manager;
+use core_reportbuilder\local\entities\base;
+use core_reportbuilder\local\filters\{date, select, text, number};
+use core_reportbuilder\local\helpers\format;
+use core_reportbuilder\local\report\{column, filter};
+use search_elastic\local\model\error as error_model;
+use lang_string;
+use stdClass;
+use html_writer;
+
+/**
+ * Report builder entity for Elasticsearch indexing errors.
+ *
+ * @package     search_elastic
+ * @copyright   2025 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class error extends base {
+
+    /**
+     * Returns the default table aliases.
+     *
+     * @return array
+     */
+    protected function get_default_tables(): array {
+        return ['search_elastic_errors'];
+    }
+
+    /**
+     * Returns the default title for this entity.
+     *
+     * @return lang_string
+     */
+    protected function get_default_entity_title(): lang_string {
+        return new lang_string('indexingerrors', 'search_elastic');
+    }
+
+    /**
+     * Initialises the entity.
+     *
+     * @return base
+     */
+    public function initialise(): base {
+        foreach ($this->get_all_columns() as $column) {
+            $this->add_column($column);
+        }
+
+        foreach ($this->get_all_filters() as $filter) {
+            $this->add_filter($filter);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns list of available columns.
+     *
+     * @return array
+     */
+    protected function get_all_columns(): array {
+        $alias = $this->get_table_alias('search_elastic_errors');
+
+        $columns[] = (new column(
+            'docid',
+            new lang_string('documentid', 'search_elastic'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TEXT)
+            ->add_field("{$alias}.docid")
+            ->add_callback(static function($value, stdClass $row): string {
+                return html_writer::tag('code', s($value));
+            })
+            ->set_is_sortable(true);
+
+        $columns[] = (new column(
+            'areaid',
+            new lang_string('areaid', 'search_elastic'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TEXT)
+            ->add_field("{$alias}.areaid")
+            ->add_callback(static function($value, stdClass $row): string {
+                // Get search area display name.
+                $searchareas = manager::get_search_areas_list(true);
+                return isset($searchareas[$value]) ? $searchareas[$value]->get_visible_name() : $value;
+            })
+            ->set_is_sortable(true);
+
+        $typeoptions = $this->get_error_type_options();
+        $columns[] = (new column(
+            'errortype',
+            new lang_string('errortype', 'search_elastic'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TEXT)
+            ->add_field("{$alias}.errortype")
+            ->add_callback(static function($value, stdClass $row) use ($typeoptions): string {
+                return $typeoptions[$row->errortype] ?? $row->errortype;
+            })
+            ->set_is_sortable(true);
+
+        $columns[] = (new column(
+            'errormessage',
+            new lang_string('errormessage', 'search_elastic'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TEXT)
+            ->add_field("{$alias}.errormessage")
+            ->add_callback(static function($value, stdClass $row): string {
+                return s($value);
+            });
+
+        $statusoptions = $this->get_status_options();
+        $columns[] = (new column(
+            'status',
+            new lang_string('status', 'search_elastic'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TEXT)
+            ->add_field("{$alias}.status")
+            ->add_callback(static function($value, stdClass $row) use ($statusoptions): string {
+                $statustext = $statusoptions[$row->status] ?? $row->status;
+
+                $statusclasses = [
+                    error_model::STATUS_RETRYING => 'badge-info',
+                    error_model::STATUS_FAILED => 'badge-danger',
+                    error_model::STATUS_OBSOLETE => 'badge-secondary',
+                ];
+
+                $class = 'badge ' . ($statusclasses[$row->status] ?? 'badge-secondary');
+                return html_writer::tag('span', $statustext, ['class' => $class]);
+            })
+            ->set_is_sortable(true);
+
+        $columns[] = (new column(
+            'retrycount',
+            new lang_string('retrycount', 'search_elastic'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_INTEGER)
+            ->add_field("{$alias}.retrycount")
+            ->set_is_sortable(true);
+
+        $columns[] = (new column(
+            'timemodified',
+            new lang_string('timemodified', 'search_elastic'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TIMESTAMP)
+            ->add_field("{$alias}.timemodified")
+            ->add_callback([format::class, 'userdate'])
+            ->set_is_sortable(true);
+
+        $columns[] = (new column(
+            'contentmodified',
+            new lang_string('contentmodified', 'search_elastic'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TIMESTAMP)
+            ->add_field("{$alias}.contentmodified")
+            ->add_callback(static function($value, stdClass $row): string {
+                return $value ? userdate($value) : '-';
+            })
+            ->set_is_sortable(true);
+
+        $columns[] = (new column(
+            'parentid',
+            new lang_string('parentid', 'search_elastic'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TEXT)
+            ->add_field("{$alias}.parentid")
+            ->add_callback(static function($value, stdClass $row): string {
+                return $value ? html_writer::tag('code', s($row->parentid)) : '-';
+            })
+            ->set_is_sortable(true);
+
+        return $columns;
+    }
+
+    /**
+     * Return list of all available filters.
+     *
+     * @return []
+     */
+    protected function get_all_filters(): array {
+        $alias = $this->get_table_alias('search_elastic_errors');
+
+        // Document ID filter.
+        $filters[] = (new filter(
+            text::class,
+            'docid',
+            new lang_string('documentid', 'search_elastic'),
+            $this->get_entity_name(),
+            "{$alias}.docid"
+        ))
+            ->add_joins($this->get_joins());
+
+        // Area ID filter.
+        $areaoptions = [];
+        $searchareas = manager::get_search_areas_list(true);
+        foreach ($searchareas as $areaid => $searcharea) {
+            $areaoptions[$areaid] = $searcharea->get_visible_name();
+        }
+
+        $filters[] = (new filter(
+            select::class,
+            'areaid',
+            new lang_string('areaid', 'search_elastic'),
+            $this->get_entity_name(),
+            "{$alias}.areaid"
+        ))
+            ->add_joins($this->get_joins())
+            ->set_options($areaoptions);
+
+        // Error type filter.
+        $typeoptions = $this->get_error_type_options();
+        $filters[] = (new filter(
+            select::class,
+            'errortype',
+            new lang_string('errortype', 'search_elastic'),
+            $this->get_entity_name(),
+            "{$alias}.errortype"
+        ))
+            ->add_joins($this->get_joins())
+            ->set_options($typeoptions);
+
+        // Status filter.
+        $statusoptions = $this->get_status_options();
+        $filters[] = (new filter(
+            select::class,
+            'status',
+            new lang_string('status', 'search_elastic'),
+            $this->get_entity_name(),
+            "{$alias}.status"
+        ))
+            ->add_joins($this->get_joins())
+            ->set_options($statusoptions);
+
+        // Retry count filter.
+        $filters[] = (new filter(
+            number::class,
+            'retrycount',
+            new lang_string('retrycount', 'search_elastic'),
+            $this->get_entity_name(),
+            "{$alias}.retrycount"
+        ))
+            ->add_joins($this->get_joins());
+
+        // Error message filter.
+        $filters[] = (new filter(
+            text::class,
+            'errormessage',
+            new lang_string('errormessage', 'search_elastic'),
+            $this->get_entity_name(),
+            "{$alias}.errormessage"
+        ))
+            ->add_joins($this->get_joins());
+
+        // Timemodified filter.
+        $filters[] = (new filter(
+            date::class,
+            'timemodified',
+            new lang_string('timemodified', 'search_elastic'),
+            $this->get_entity_name(),
+            "{$alias}.timemodified"
+        ))
+            ->add_joins($this->get_joins());
+
+        // Content modified filter.
+        $filters[] = (new filter(
+            date::class,
+            'contentmodified',
+            new lang_string('contentmodified', 'search_elastic'),
+            $this->get_entity_name(),
+            "{$alias}.contentmodified"
+        ))
+            ->add_joins($this->get_joins());
+
+        // Parent ID filter.
+        $filters[] = (new filter(
+            text::class,
+            'parentid',
+            new lang_string('parentid', 'search_elastic'),
+            $this->get_entity_name(),
+            "{$alias}.parentid"
+        ))
+            ->add_joins($this->get_joins());
+
+        return $filters;
+    }
+
+    /**
+     * Returns an array of error type options.
+     *
+     * @return array
+     */
+    private function get_error_type_options(): array {
+        return [
+            error_model::TYPE_INDEXING => get_string('type_indexing', 'search_elastic'),
+            error_model::TYPE_TIKA => get_string('type_tika', 'search_elastic'),
+        ];
+    }
+
+    /**
+     * Returns an array of status options.
+     *
+     * @return array
+     */
+    private function get_status_options(): array {
+        return [
+            error_model::STATUS_RETRYING => get_string('status_retrying', 'search_elastic'),
+            error_model::STATUS_FAILED => get_string('status_failed', 'search_elastic'),
+            error_model::STATUS_OBSOLETE => get_string('status_obsolete', 'search_elastic'),
+        ];
+    }
+
+}

--- a/classes/reportbuilder/local/systemreports/errors.php
+++ b/classes/reportbuilder/local/systemreports/errors.php
@@ -1,0 +1,194 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic\reportbuilder\local\systemreports;
+
+use context;
+use context_system;
+use core_reportbuilder\local\report\action;
+use core_reportbuilder\system_report;
+use search_elastic\reportbuilder\local\entities\error;
+use search_elastic\error_action_handler;
+use search_elastic\local\model\error as error_model;
+use moodle_url;
+use lang_string;
+use pix_icon;
+use stdClass;
+
+/**
+ * Search elastic errors system report.
+ *
+ * @package     search_elastic
+ * @copyright   2025 Catalyst IT
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class errors extends system_report {
+
+    /**
+     * Initialise the report.
+     *
+     * @return void
+     */
+    protected function initialise(): void {
+        $errorentity = new error();
+        $erroralias = $errorentity->get_table_alias('search_elastic_errors');
+
+        $this->set_main_table('search_elastic_errors', $erroralias);
+        $this->add_entity($errorentity);
+
+        // Any columns required by actions should be defined here to ensure they're always available.
+        $this->add_base_fields("{$erroralias}.id, {$erroralias}.status");
+
+        // Add default columns.
+        $this->add_columns_from_entity($errorentity->get_entity_name(), [
+            'docid',
+            'areaid',
+            'errortype',
+            'errormessage',
+            'status',
+            'retrycount',
+            'timemodified',
+            'contentmodified',
+            'parentid',
+        ]);
+
+        // Add default filters.
+        $this->add_filters_from_entity($errorentity->get_entity_name(), [
+            'docid',
+            'areaid',
+            'errortype',
+            'errormessage',
+            'status',
+            'retrycount',
+            'timemodified',
+            'contentmodified',
+            'parentid',
+        ]);
+
+        $this->add_actions();
+
+        // Default sorting.
+        $this->set_initial_sort_column($errorentity->get_entity_name() . ':timemodified', SORT_DESC);
+
+        $this->set_downloadable(true);
+    }
+
+    /**
+     * Add the system report actions. An extra column will be appended to each row, containing all actions added here.
+     *
+     * Note the use of ":id" placeholder which will be substituted according to actual values in the row.
+     */
+    protected function add_actions(): void {
+        $baseurl = new moodle_url('/search/engine/elastic/errors.php');
+
+        $this->add_action((new action(
+            new moodle_url($baseurl, [
+                'action' => error_action_handler::ACTION_RETRY_SINGLE,
+                'id' => ':id',
+                'sesskey' => sesskey(),
+                'confirm' => 1,
+            ]),
+            new pix_icon('t/play', '', 'core'),
+            [
+                'data-confirmation' => 'modal',
+                'data-confirmation-title-str' => json_encode(['retry', 'search_elastic']),
+                'data-confirmation-content-str' => json_encode(['confirm:retrysingle', 'search_elastic']),
+                'data-confirmation-yes-button-str' => json_encode(['retry', 'search_elastic']),
+            ],
+            false,
+            new lang_string('retry', 'core')
+        ))
+            ->add_callback(function(stdClass $row): bool {
+                // Only show retry button for retrying or failed errors.
+                return in_array($row->status, [error_model::STATUS_RETRYING, error_model::STATUS_FAILED]);
+            }));
+
+        $this->add_action((new action(
+            new moodle_url($baseurl, [
+                'action' => error_action_handler::ACTION_DELETE_SINGLE,
+                'id' => ':id',
+                'sesskey' => sesskey(),
+                'confirm' => 1,
+            ]),
+            new pix_icon('t/delete', '', 'core'),
+            [
+                'data-confirmation' => 'modal',
+                'data-confirmation-title-str' => json_encode(['delete', 'core']),
+                'data-confirmation-content-str' => json_encode(['confirm:delete', 'search_elastic']),
+                'data-confirmation-yes-button-str' => json_encode(['delete', 'core']),
+            ],
+            false,
+            new lang_string('delete', 'core')
+        )));
+    }
+
+    /**
+     * Returns report context.
+     *
+     * @return \context
+     */
+    public function get_context(): context {
+        return context_system::instance();
+    }
+
+    /**
+     * Check if can view this system report.
+     *
+     * @return bool
+     */
+    protected function can_view(): bool {
+        return has_capability('moodle/site:config', $this->get_context());
+    }
+
+
+    /**
+     * Return the columns that will be added to the report once it's created.
+     *
+     * @return array
+     */
+    public function get_default_columns(): array {
+        return [
+            'error:docid',
+            'error:areaid',
+            'error:errortype',
+            'error:errormessage',
+            'error:status',
+            'error:retrycount',
+            'error:timemodified',
+            'error:contentmodified',
+            'error:parentid',
+        ];
+    }
+
+    /**
+     * Return the filters that will be added to the report once it's created.
+     *
+     * @return array
+     */
+    public function get_default_filters(): array {
+        return [
+            'error:docid',
+            'error:areaid',
+            'error:errortype',
+            'error:errormessage',
+            'error:status',
+            'error:retrycount',
+            'error:timemodified',
+            'error:contentmodified',
+            'error:parentid',
+        ];
+    }
+}

--- a/classes/task/retry_errors_task.php
+++ b/classes/task/retry_errors_task.php
@@ -1,0 +1,166 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic\task;
+
+use core\lock\lock_config;
+use core\task\adhoc_task;
+use Exception;
+use search_elastic\engine;
+use search_elastic\error_action_handler;
+use search_elastic\local\model\error;
+use search_elastic\local\service\error_service;
+
+/**
+ * Adhoc task for retrying Elasticsearch errors.
+ *
+ * @package    search_elastic
+ * @author     Trisha Milan <trishamilan@catalyst-au.net>
+ * @copyright  2025 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class retry_errors_task extends adhoc_task {
+
+    /**
+     * Get a descriptive name for this task (shown to admins).
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('retryerrorstask', 'search_elastic');
+    }
+
+    /**
+     * Do the job.
+     * Throw exceptions on errors (the job will be retried).
+     */
+    public function execute() {
+        $data = $this->get_custom_data();
+        $operation = $data->operation ?? error_action_handler::ACTION_RETRY_ALL_FAILED;
+        $errorid = $data->errorid ?? null;
+
+        $results = [
+            'processed' => 0,
+            'success' => 0,
+            'failed' => 0,
+            'operation' => $operation,
+        ];
+
+        switch ($operation) {
+            case error_action_handler::ACTION_RETRY_SINGLE:
+                $results = $this->retry_single($errorid);
+                break;
+            case error_action_handler::ACTION_RETRY_ALL_FAILED:
+            default:
+                $lockfactory = lock_config::get_lock_factory('search_elastic');
+                $lock = $lockfactory->get_lock('retry_all_failed', 10);
+                if (!$lock) {
+                    mtrace('Unable to obtain lock for retry_all_failed - another task is running.');
+                    return;
+                }
+                $results = $this->retry_all_failed(true);
+                $lock->release();
+        }
+
+        mtrace('Retry task completed: ' . $operation . ' - ' .
+                'processed: ' . $results['processed'] . ', ' .
+                'success: ' . $results['success'] . ', ' .
+                'failed: ' . $results['failed']);
+    }
+
+    /**
+     * Retry a single error.
+     *
+     * @param int $errorid
+     * @return array
+     */
+    private function retry_single($errorid): array {
+        $successcount = 0;
+        $errorcount = 0;
+
+        try {
+            $error = new error($errorid);
+            mtrace("Processing document ID: {$error->get('docid')} with areaid: {$error->get('areaid')}");
+            $result = error_service::retry_error($errorid);
+            if ($result['success']) {
+                mtrace("Successfully indexed document ID: {$error->get('docid')}");
+                $successcount++;
+            } else {
+                $errorcount++;
+                $error->mark_failed();
+                mtrace("Failed to retry error ID {$errorid}: {$result['message']}");
+            }
+
+        } catch (Exception $e) {
+            $errorcount++;
+            mtrace("Exception retrying error ID {$errorid}: " . $e->getMessage());
+        }
+
+        return  [
+            'processed' => 1,
+            'success' => $successcount,
+            'failed' => $errorcount,
+        ];
+    }
+
+    /**
+     * Retry all failed.
+     *
+     * @return array
+     */
+    private function retry_all_failed(): array {
+        $errors = error::get_records(['status' => error::STATUS_FAILED]);
+        if (empty($errors)) {
+            mtrace(get_string('noerrors', 'search_elastic'));
+            return ['processed' => 0, 'success' => 0, 'failed' => 0];
+        }
+
+        $successcount = 0;
+        $errorcount = 0;
+        $processed = 0;
+
+        $engine = new engine();
+        $batchsize = $engine->get_batch_max_documents();
+
+        // Process in batches.
+        foreach (array_chunk($errors, $batchsize) as $batch) {
+            foreach ($batch as $error) {
+                try {
+                    mtrace("Processing document ID: {$error->get('docid')} with areaid: {$error->get('areaid')}");
+                    $result = error_service::retry_error($error->get('id'));
+                    if ($result['success']) {
+                        mtrace("Successfully indexed document ID: {$error->get('docid')}");
+                        $successcount++;
+                    } else {
+                        $errorcount++;
+                        mtrace("Failed to retry error ID {$error->get('id')}: {$result['message']}");
+                    }
+                } catch (Exception $e) {
+                    $errorcount++;
+                    mtrace("Exception retrying error ID {$error->get('id')}: " . $e->getMessage());
+                }
+
+                $processed++;
+            }
+        }
+
+        return [
+            'processed' => $processed,
+            'success' => $successcount,
+            'failed' => $errorcount,
+        ];
+    }
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="search/engine/elastic/db" VERSION="2025062708" COMMENT="XMLDB file for Moodle search/engine/elastic"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
+>
+  <TABLES>
+    <TABLE NAME="search_elastic_errors" COMMENT="Tracks documents that failed indexing or text extraction.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="docid" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="itemid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="contextid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="areaid" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="errortype" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="errormessage" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="retrycount" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" DEFAULT="0"/>
+        <FIELD NAME="status" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false" DEFAULT="failed"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="contentmodified" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="parentid" TYPE="char" LENGTH="100" NOTNULL="false" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="docid" UNIQUE="false" FIELDS="docid"/>
+        <INDEX NAME="contextid" UNIQUE="false" FIELDS="contextid"/>
+        <INDEX NAME="areaid" UNIQUE="false" FIELDS="areaid"/>
+        <INDEX NAME="status" UNIQUE="false" FIELDS="status"/>
+        <INDEX NAME="errortype" UNIQUE="false" FIELDS="errortype"/>
+        <INDEX NAME="parentid" UNIQUE="false" FIELDS="parentid"/>
+      </INDEXES>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -31,6 +31,8 @@
 function xmldb_search_elastic_upgrade($oldversion) {
     global $DB;
 
+    $dbman = $DB->get_manager();
+
     if ($oldversion < 2019042101) {
         // Check for corrupt index definition and fix if required.
         // Fix involves deleting all indexed documents.
@@ -68,6 +70,44 @@ function xmldb_search_elastic_upgrade($oldversion) {
                        WHERE plugin = 'search_elastic' AND name = 'hostname' AND value = 'http://127.0.0.1'");
 
         upgrade_plugin_savepoint(true, 2023092000, 'search', 'elastic');
+    }
+
+    if ($oldversion < 2025062708) {
+        // Define table search_elastic_errors to be created.
+        $table = new xmldb_table('search_elastic_errors');
+
+        // Adding fields to the search_elastic_errors.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE);
+        $table->add_field('docid', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL);
+        $table->add_field('itemid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL);
+        $table->add_field('contextid', XMLDB_TYPE_INTEGER, '10', null, null);
+        $table->add_field('areaid', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL);
+        $table->add_field('errortype', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL);
+        $table->add_field('errormessage', XMLDB_TYPE_TEXT, null, null, null);
+        $table->add_field('retrycount', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('status', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'failed');
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL);
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL);
+        $table->add_field('contentmodified', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('parentid', XMLDB_TYPE_CHAR, '100', null, null);
+
+        // Adding keys to table search_elastic_errors.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Adding indexes to table search_elastic_errors.
+        $table->add_index('docid', XMLDB_INDEX_NOTUNIQUE, ['docid']);
+        $table->add_index('contextid', XMLDB_INDEX_NOTUNIQUE, ['contextid']);
+        $table->add_index('areaid', XMLDB_INDEX_NOTUNIQUE, ['areaid']);
+        $table->add_index('status', XMLDB_INDEX_NOTUNIQUE, ['status']);
+        $table->add_index('errortype', XMLDB_INDEX_NOTUNIQUE, ['errortype']);
+        $table->add_index('parentid', XMLDB_INDEX_NOTUNIQUE, ['parentid']);
+
+        // Conditionally launch create table for search_elastic_errors.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        upgrade_plugin_savepoint(true, 2025062708, 'search', 'elastic');
     }
 
     return true;

--- a/errors.php
+++ b/errors.php
@@ -1,0 +1,100 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Elasticsearch indexing errors management page.
+ *
+ * @package    search_elastic
+ * @author     Trisha Milan <trishamilan@catalyst-au.net>
+ * @copyright  2025 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(dirname(__FILE__) . '/../../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
+
+use core\notification;
+use search_elastic\error_action_handler;
+use search_elastic\local\model\error;
+use search_elastic\local\service\error_service;
+use core_reportbuilder\system_report_factory;
+use search_elastic\reportbuilder\local\systemreports\errors;
+
+defined('MOODLE_INTERNAL') || die();
+
+admin_externalpage_setup('search_elastic_errors');
+
+// Get parameters.
+$action = optional_param('action', '', PARAM_ALPHAEXT);
+$errorid = optional_param('id', 0, PARAM_INT);
+$confirm = optional_param('confirm', 0, PARAM_BOOL);
+
+$context = context_system::instance();
+
+$PAGE->set_url(new moodle_url('/search/engine/elastic/errors.php'));
+
+if ($action && confirm_sesskey()) {
+    error_action_handler::handle_action($action, $errorid, $PAGE->url, $confirm);
+}
+
+// Build the page output.
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('indexingerrors', 'search_elastic'));
+
+$failedcount = error_service::get_error_count_by_status(error::STATUS_FAILED);
+$obsoletecount = error_service::get_error_count_by_status(error::STATUS_OBSOLETE);
+$buttons = [];
+if ($failedcount > 0) {
+    $retryallfailed = new moodle_url($PAGE->url, [
+        'action' => error_action_handler::ACTION_RETRY_ALL_FAILED,
+        'sesskey' => sesskey(),
+        'confirm' => 1,
+    ]);
+
+    $buttons[] = $OUTPUT->single_button($retryallfailed, get_string('retryallfailed', 'search_elastic'), 'post', [
+        'data-confirmation' => 'modal',
+        'data-confirmation-title-str' => json_encode(['retryallfailed', 'search_elastic']),
+        'data-confirmation-content-str' => json_encode(['confirm:retryallfailed', 'search_elastic']),
+        'data-confirmation-yes-button-str' => json_encode(['confirm', 'core']),
+        'title' => get_string('retryallfailed_desc', 'search_elastic'),
+    ]);
+}
+
+if ($obsoletecount > 0) {
+    $removeallobsolete = new moodle_url($PAGE->url, [
+        'action' => error_action_handler::ACTION_DELETE_ALL_OBSOLETE,
+        'sesskey' => sesskey(),
+        'confirm' => 1,
+    ]);
+
+    $buttons[] = $OUTPUT->single_button($removeallobsolete, get_string('removeallobsolete', 'search_elastic'), 'post', [
+        'data-confirmation' => 'modal',
+        'data-confirmation-title-str' => json_encode(['removeallobsolete', 'search_elastic']),
+        'data-confirmation-content-str' => json_encode(['confirm:removeallobsolete', 'search_elastic']),
+        'data-confirmation-yes-button-str' => json_encode(['confirm', 'core']),
+        'title' => get_string('removeallobsolete_desc', 'search_elastic'),
+    ]);
+}
+
+if (!empty($buttons)) {
+    echo html_writer::div(implode('', $buttons), 'mb-3');
+}
+
+// Create and display the report.
+$report = system_report_factory::create(errors::class, $context);
+echo $report->output();
+
+echo $OUTPUT->footer();

--- a/lang/en/search_elastic.php
+++ b/lang/en/search_elastic.php
@@ -22,22 +22,23 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$string['pluginname'] = 'Elastic';
-$string['pluginname_help'] = 'Search backend for the Elasticsearch search engine';
-
+$string['actions'] = 'Actions';
 $string['addfail'] = 'Failed to add document to index';
+$string['adminsettings'] = 'Plugin settings';
 $string['advsettings'] = 'Advanced settings';
+$string['all'] = 'All';
 $string['apikey'] = 'API key';
 $string['apikey_help'] = 'Some Elasticsearch providers such as  Elastic Cloud require API key to authorize HTTP requests.';
+$string['areaid'] = 'Area ID';
 $string['aws'] = 'AWS';
-$string['adminsettings'] = 'Plugin settings';
 $string['basicsettings'] = 'Basic settings';
 $string['boostdescription'] = 'These settings control the boosting settings for the search areas. Areas with higher values will be boosted more and will appear higher in the search results. A Boost value of 20 will make the area weighted 2x as high as an area with value 10.';
 $string['boostsettings'] = 'Boosting settings';
 $string['boostvalue'] = '';
 $string['boostvalue_help'] = 'Set the value you want this search area to be boosted by in the search results. Higher boost values give more priority.';
 $string['checkserver_ready_check'] = 'Elastic server connection';
-$string['connectiontest'] = 'Server connection test';
+$string['clearsearch'] = 'Clear Search';
+$string['clearsearchdesc'] = 'Remove all search filters';
 $string['complexhelptext'] = 'The field to be searched may be specified by prefixing the search query with \'title:\', \'content:\', \'name:\', or \'intro:\'. For example, searching for \'title:news\' would return results with the word \'news\' in the title.
 <br>
 Boolean operators (\'AND\', \'OR\') may be used to combine or exclude keywords.
@@ -46,31 +47,48 @@ Wildcard characters (\'*\' or \'?\' ) may be used to represent characters in the
 <br>
 For more information, follow this link: {$a}';
 $string['complexhelpurl'] = 'https://lucene.apache.org/core/2_9_4/queryparsersyntax.html';
+$string['confirm:delete'] = 'Are you sure you want to delete this record?';
+$string['confirm:removeallobsolete'] = 'Are you sure you want to delete all obsolete errors? This action cannot be undone.';
+$string['confirm:retryallfailed'] = 'Are you sure you want to retry all errors? This will queue a background task to reprocess the failed documents.';
+$string['confirm:retrysingle'] = 'Are you sure you want to retry indexing this record?';
 $string['connection:na'] = 'Server not configured';
 $string['connection:status'] = 'The configured elastic server at {$a->url} returned the status code {$a->status}';
+$string['connectiontest'] = 'Server connection test';
 $string['connecttimeout'] = 'Connect timeout (seconds)';
 $string['connecttimeout_help'] = 'Guzzle connection timeout. Use 0 to disable. See https://docs.guzzlephp.org/en/stable/request-options.html#connect-timeout';
+$string['contentmodified'] = 'Content modified';
+$string['delete'] = 'Delete';
+$string['deletedobsoleteerrors'] = 'Successfully deleted {$a} obsolete errors';
+$string['deletedsuccessfully'] = 'Error ID {$a} has been deleted successfully.';
+$string['deleteobsoleteexception'] = 'Exception occured while deleting obsolete errors: {$a}';
+$string['documentid'] = 'Document ID';
 $string['enrichdesc'] = 'Global Search can enrich the indexed data used in search by extracting text and other data from files.
 The data extracted from files in Moodle is controlled by the following groups of settings.';
 $string['enrichsettings'] = 'Data enrichment settings';
-$string['fileindexselect'] = 'File processor';
-$string['fileindexselect_help'] = 'Select the file processor or service that will extract text from files. The form will update with the settings for the chosen service.';
+$string['erroridnotfound'] = 'Unable to find error ID: {$a}';
+$string['errormessage'] = 'Error message';
+$string['errortype'] = 'Error type';
+$string['exceededmaxretries'] = 'Maximum retries exceeded';
 $string['fileindexing'] = 'Enable file indexing';
 $string['fileindexing_help'] = 'Enables file indexing for this plugin.';
-$string['fileindexsettingsdesc'] = 'Before files can be processed and their content and information extracted file indexing for Global Search needs to be enabled.';
+$string['fileindexselect'] = 'File processor';
+$string['fileindexselect_help'] = 'Select the file processor or service that will extract text from files. The form will update with the settings for the chosen service.';
 $string['fileindexsettings'] = 'File indexing';
 $string['fileindexsettings_help'] = 'Enter the details for the Tika service. These are required if file indexing is enabled above.';
+$string['fileindexsettingsdesc'] = 'Before files can be processed and their content and information extracted file indexing for Global Search needs to be enabled.';
 $string['hostname'] = 'Hostname';
 $string['hostname_help'] = 'The FQDN of the Elasticsearch engine endpoint';
-$string['index'] = 'Index';
-$string['index_help'] = 'Namespace index to store search data in backend';
 $string['imageindexselect'] = 'Image processor';
 $string['imageindexselect_help'] = 'Select the image processor or service that will extract information out of your images. The form will update with the settings for the chosen service.';
 $string['imagerecognitionsettings'] = 'Image recognition';
 $string['imagerecognitionsettingsdesc'] = 'Image recognition extracts details about the content of an image and adds these to the search index.
 
 These settings control what process or service is used to extract data out of an image and how the image data is added to the search engine.';
+$string['index'] = 'Index';
+$string['index_help'] = 'Namespace index to store search data in backend';
 $string['indexfail'] = 'Failed to create index';
+$string['indexingerrors'] = 'Indexing errors';
+$string['invaliderrorid'] = 'Invalid error ID';
 $string['logging'] = 'Query logging';
 $string['logging_help'] = 'If enabled all search queries and the raw results from Elasticsearch will be added to the error log';
 $string['maxlabels'] = 'Maxiumum Labels';
@@ -78,10 +96,15 @@ $string['maxlabels_help'] = 'The maximum number of result labels returned by Rek
 $string['minconfidence'] = 'Minimum confidence';
 $string['minconfidence_help'] = 'Reckognition will only return labels with a confidence above this';
 $string['noconfig'] = 'Elasticsearch configuration missing';
+$string['noerrors'] = 'No errors found.';
 $string['none'] = 'None';
 $string['noserver'] = 'Elasticsearch endpoint unreachable';
 $string['order_newest'] = 'Newest first';
 $string['order_oldest'] = 'Oldest first';
+$string['parentid'] = 'Parent ID';
+$string['pluginname'] = 'Elastic';
+$string['pluginname_help'] = 'Search backend for the Elasticsearch search engine';
+
 $string['pluginsettings'] = 'Plugin Settings';
 $string['port'] = 'Port';
 $string['port_help'] = 'The Port of the Elasticsearch engine endpoint';
@@ -93,20 +116,37 @@ $string['queryerror'] = 'Error executing query in search engine: {$a->reason}
 $string['reachable'] = 'Elasticsearch endpoint reachable';
 $string['region'] = 'Region';
 $string['region_help'] = 'The AWS region the Elasticsearch instance is in, e.g. ap-southeast-2';
-$string['rekregion'] = 'Region';
-$string['rekregion_help'] = 'The AWS region the Rekognition service is in, e.g. us-west-2';
 $string['rekkeyid'] = 'Key ID';
 $string['rekkeyid_help'] = 'The ID of the key to use to access Rekcognition.';
-$string['reksecretkey'] = 'Secret Key';
-$string['reksecretkey_help'] = 'The secret key to use to access Rekcognition.';
 $string['rekognitionsettings'] = 'AWS Rekognition settings';
 $string['rekognitionsettings_help'] = 'Settings to configure image recognition and indexing using the AWS Rekognition service.';
+$string['rekregion'] = 'Region';
+$string['rekregion_help'] = 'The AWS region the Rekognition service is in, e.g. us-west-2';
+$string['reksecretkey'] = 'Secret Key';
+$string['reksecretkey_help'] = 'The secret key to use to access Rekcognition.';
+$string['removeallobsolete'] = 'Remove all obsolete';
+$string['removeallobsolete_desc'] = 'Delete all error records that have obsolete status from database.';
+$string['retry'] = 'Retry';
+$string['retryallfailed'] = 'Retry all failed';
+$string['retryallfailed_desc'] = 'Queue background task to reattempt indexing for failed documents.';
+$string['retryallqueued'] = 'Background task queued to retry all errors.';
+$string['retrycount'] = 'Retry count';
+$string['retryerrorstask'] = 'Retry Elasticsearch errors';
+$string['retrysingleadhoc'] = 'Background task queued to retry the error.';
+$string['searcharea'] = 'Search area';
+$string['searchareanotfound'] = 'Search area not found';
+$string['searchdocumentid'] = 'Document ID';
+$string['searchdocumentidplaceholder'] = 'Enter document ID to search...';
+$string['searcherrors'] = 'Search errors';
 $string['searchinfo'] = 'Search queries';
 $string['searchinfo_help'] = 'The field to be searched may be specified by prefixing the search query with \'title:\', \'content:\', \'name:\', or \'intro:\'. For example, searching for \'title:news\' would return results with the word \'news\' in the title.
 
 Boolean operators (\'AND\', \'OR\') may be used to combine or exclude keywords.
 
 Wildcard characters (\'*\' or \'?\' ) may be used to represent characters in the search query.';
+$string['searchmessage'] = 'Error message';
+$string['searchmessageplaceholder'] = 'Search in error messages...';
+$string['searchresultsinfo'] = 'Showing {$a->filtered} of {$a->total} total errors';
 $string['searchsettings'] = 'Search settings';
 $string['sendsize'] = 'Request size';
 $string['sendsize_help'] = 'Some Elasticsearch providers such as AWS have a limit on how big the HTTP payload can be. Therefore we limit it to a size in bytes.';
@@ -130,6 +170,10 @@ Minus (\'-\') may be used to negate search terms.
 <br>
 For more information, follow this link: {$a}';
 $string['simplehelpurl'] = 'https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html';
+$string['status'] = 'Status';
+$string['status_failed'] = 'Failed';
+$string['status_obsolete'] = 'Obsolete';
+$string['status_retrying'] = 'Retrying';
 $string['textextractionsettings'] = 'Text extraction';
 $string['textextractionsettingsdesc'] = 'Text extraction takes the actual text contained in a file and adds it as searchable content to the search index.';
 $string['tika'] = 'Apache Tika';
@@ -139,15 +183,19 @@ $string['tikaport'] = 'Tika Port';
 $string['tikaport_help'] = 'The Port of the Apache Tika endpoint';
 $string['tikasendsize'] = 'Maximum file size';
 $string['tikasendsize_help'] = 'Sending large files to Tika can cause out of memory issues. Therefore we limit it to a size in bytes.';
+$string['timecreated'] = 'Created';
+$string['timemodified'] = 'Timemodified';
+$string['type_indexing'] = 'Indexing';
+$string['type_tika'] = 'Tika';
 $string['usesimplequery'] = 'Use simple query';
 $string['usesimplequery_help'] = 'Simple queries reduce the amount of operators usable, but allow for partial returns on malformed queries.
 
 Standard syntax information: {$a->complex}
 
 Simple syntax information: {$a->simple}';
-$string['wildcardstart'] = 'Wildcard at the start';
-$string['wildcardstart_help'] = 'When enabled Moodle will add implicit wildcards at the start of search terms. This can improve behaviour of searches.
-For example: searching for "scrip" will become "*scrip" prior to be sent to the search engine. This means the search will now match "script" and "description".';
 $string['wildcardend'] = 'Wildcard at the end';
 $string['wildcardend_help'] = 'When enabled Moodle will add implicit wildcards at the end of search terms. This can improve behaviour of searches.
 For example: searching for "math" will become "math*" prior to be sent to the search engine. This means the search will now match "math", "maths" and "mathematics".';
+$string['wildcardstart'] = 'Wildcard at the start';
+$string['wildcardstart_help'] = 'When enabled Moodle will add implicit wildcards at the start of search terms. This can improve behaviour of searches.
+For example: searching for "scrip" will become "*scrip" prior to be sent to the search engine. This means the search will now match "script" and "description".';

--- a/settings.php
+++ b/settings.php
@@ -105,7 +105,12 @@ if ($hassiteconfig) {
             get_string('enrichsettings', 'search_elastic'),
             new moodle_url('/search/engine/elastic/enrich.php'));
 
+    $errorreport = new admin_externalpage('search_elastic_errors',
+            get_string('indexingerrors', 'search_elastic'),
+            new moodle_url('/search/engine/elastic/errors.php'));
+
     $ADMIN->add('search_elastic', $settings);
     $ADMIN->add('search_elastic', $enrichsettings);
+    $ADMIN->add('search_elastic', $errorreport);
     $settings = null;
 }

--- a/tests/fixtures/mixed_valid_invalid_payload.json
+++ b/tests/fixtures/mixed_valid_invalid_payload.json
@@ -1,0 +1,8 @@
+{"index":{"_index":"moodle","_type":"doc","_id":"mod_folder-activity-1"}}
+{"areaid":"mod_folder-activity","id":"mod_folder-activity-1","itemid":1,"title":"Test folder 1","content":"","contextid":"100","courseid":"8","owneruserid":"0","modified":"1753319565","type":1,"parentid":"mod_folder-activity-1"}
+{"invalid metadata"}
+{"areaid":"mod_assign-activity","id":"mod_assign-activity-1","itemid":2,"title":"Test Assign 1","content":"","contextid":"418","courseid":"8","owneruserid":"0","modified":"1753319565","type":1,"parentid":"mod_assign-activity-1"}
+{"index":{"_index":"moodle","_type":"doc","_id":"mod_folder-activity-2"}}
+{"areaid":"mod_folder-activity","id":"mod_folder-activity-2","itemid":3,"title":"Test folder 2","content":"","contextid":"120","courseid":"8","owneruserid":"0","modified":"1753319565","type":1,"parentid":"mod_folder-activity-2"}
+{"index":{"_index":"moodle","_type":"doc","_id":"mod_folder-activity-2"}}
+{"invalid document"}

--- a/tests/fixtures/test_payload.json
+++ b/tests/fixtures/test_payload.json
@@ -1,0 +1,8 @@
+{"index":{"_index":"moodle","_type":"doc","_id":"mod_folder-activity-6"}}
+{"areaid":"mod_folder-activity","id":"mod_folder-activity-6","itemid":6,"title":"Test folder","content":"","contextid":"418","courseid":"8","owneruserid":"0","modified":"1753319565","type":1,"parentid":"mod_folder-activity-6"}
+{"index":{"_index":"moodle","_type":"doc","_id":"588"}}
+{"areaid":"mod_folder-activity","id":"588","itemid":6,"title":"test1.pdf","contextid":"418","courseid":"8","owneruserid":"0","modified":"1753319565","type":2,"parentid":"mod_folder-activity-6","filetext":"\nSample file text 1","filecontenthash":"5956f9e0aeedcfff463e66dff87ec4941be67744"}
+{"index":{"_index":"moodle","_type":"doc","_id":"590"}}
+{"areaid":"mod_folder-activity","id":"590","itemid":6,"title":"test2.pdf","contextid":"418","courseid":"8","owneruserid":"0","modified":"1753319565","type":2,"parentid":"mod_folder-activity-6","filetext":"\nSample file text 2","filecontenthash":"7c312907e35577877dbc57bfdf2c909cba936838"}
+{"index":{"_index":"moodle","_type":"doc","_id":"591"}}
+{"areaid":"mod_folder-activity","id":"591","itemid":6,"title":"test3.pdf","contextid":"418","courseid":"8","owneruserid":"0","modified":"1753319565","type":2,"parentid":"mod_folder-activity-6","filetext":"\nSample file text3","filecontenthash":"9b11c4d918a8dbe2a1f79a8ca7327ff0640750f0"}

--- a/tests/local/service/error_service_test.php
+++ b/tests/local/service/error_service_test.php
@@ -1,0 +1,552 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic\local\service;
+
+use advanced_testcase;
+use context_course;
+use core_search\manager;
+use search_elastic\local\model\error;
+use search_elastic\local\service\error_service;
+use search_elastic\testable_engine;
+use core_mocksearch\search\mock_search_area;
+use stdClass;
+use stored_file;
+use testable_core_search;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/search/tests/fixtures/testable_core_search.php');
+require_once($CFG->dirroot . '/search/tests/fixtures/mock_search_area.php');
+require_once($CFG->dirroot . '/search/engine/elastic/tests/fixtures/testable_engine.php');
+
+/**
+ * Tests for error service class.
+ *
+ * @package     search_elastic
+ * @copyright   2025 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers      \search_elastic\local\service\error_service
+ */
+final class error_service_test extends advanced_testcase {
+
+    /**
+     * @var \core_search::manager
+     */
+    protected $search = null;
+
+    /**
+     * @var Instance of core_search_generator.
+     */
+    protected $generator = null;
+
+    /**
+     * @var Instance of testable_engine.
+     */
+    protected $engine = null;
+
+    /**
+     * @var mock_search_area
+     */
+    protected $area = null;
+
+    /**
+     * @var stdClass Test course.
+     */
+    protected $course = null;
+
+    /**
+     * @var context_course Test course context.
+     */
+    protected $coursecontext = null;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        set_config('enableglobalsearch', true);
+
+        // Set up basic search engine configuration.
+        set_config('hostname', 'http://localhost', 'search_elastic');
+        set_config('port', '9200', 'search_elastic');
+        set_config('index', 'test_index', 'search_elastic');
+
+        $this->generator = self::getDataGenerator()->get_plugin_generator('core_search');
+        $this->generator->setup();
+
+        $this->engine = new testable_engine();
+        $this->search = testable_core_search::instance($this->engine);
+
+        $areaid = manager::generate_areaid('core_mocksearch', 'mock_search_area');
+        $this->area = new mock_search_area();
+        $this->search->add_search_area($areaid, $this->area);
+
+        // Create test course and context.
+        $this->course = $this->getDataGenerator()->create_course();
+        $this->coursecontext = context_course::instance($this->course->id);
+
+        $this->setAdminUser();
+    }
+
+    /**
+     * Test save_error method with new error.
+     */
+    public function test_save_error_new(): void {
+        global $DB;
+
+        $docid = 'test_doc_123';
+        $itemid = 456;
+        $contextid = $this->coursecontext->id;
+        $areaid = 'core_mocksearch-mock_search_area';
+        $errortype = error::TYPE_INDEXING;
+        $errormessage = 'Test error message';
+        $contentmodified = time();
+
+        // Ensure no existing error.
+        $this->assertEquals(0, $DB->count_records('search_elastic_errors'));
+
+        error_service::save_error($docid, $itemid, $contextid, $areaid, $errortype, $errormessage, $contentmodified);
+
+        // Check error was created.
+        $errors = $DB->get_records('search_elastic_errors');
+        $this->assertCount(1, $errors);
+
+        $error = reset($errors);
+        $this->assertEquals($docid, $error->docid);
+        $this->assertEquals($itemid, $error->itemid);
+        $this->assertEquals($contextid, $error->contextid);
+        $this->assertEquals($areaid, $error->areaid);
+        $this->assertEquals($errortype, $error->errortype);
+        $this->assertEquals($errormessage, $error->errormessage);
+        $this->assertEquals($contentmodified, $error->contentmodified);
+        $this->assertEquals(0, $error->retrycount);
+        $this->assertEquals(error::STATUS_FAILED, $error->status);
+    }
+
+    /**
+     * Test save_error method with existing error should update.
+     */
+    public function test_save_error_existing(): void {
+        global $DB;
+
+        $docid = 'test_doc_123';
+        $itemid = 456;
+        $contextid = $this->coursecontext->id;
+        $areaid = 'core_mocksearch-mock_search_area';
+        $errortype = error::TYPE_INDEXING;
+        $errormessage = 'Test error message';
+        $contentmodified = time();
+
+        // Create initial error.
+        error_service::save_error($docid, $itemid, $contextid, $areaid, $errortype, $errormessage, $contentmodified);
+
+        $initialcount = $DB->count_records('search_elastic_errors');
+        $this->assertEquals(1, $initialcount);
+
+        // Update with same error details.
+        $newerrormessage = 'Updated error message';
+        error_service::save_error($docid, $itemid, $contextid, $areaid, $errortype, $newerrormessage, $contentmodified);
+
+        // Should still have only one record.
+        $this->assertEquals(1, $DB->count_records('search_elastic_errors'));
+
+        $error = $DB->get_record('search_elastic_errors', ['docid' => $docid]);
+        $this->assertEquals($newerrormessage, $error->errormessage);
+        $this->assertEquals(error::STATUS_FAILED, $error->status);
+    }
+
+    /**
+     * Test get_error_count_by_status method.
+     */
+    public function test_get_error_count_by_status(): void {
+        // Create errors with different statuses.
+        error_service::save_error('doc1', 1, $this->coursecontext->id, 'area1', error::TYPE_INDEXING, 'Message 1', time());
+        error_service::save_error('doc2', 2, $this->coursecontext->id, 'area2', error::TYPE_INDEXING, 'Message 2', time());
+        error_service::save_error('doc3', 3, $this->coursecontext->id, 'area3', error::TYPE_TIKA, 'Message 3', time());
+
+        // Update one to failed status.
+        $error = error::get_record(['docid' => 'doc2']);
+        $error->set('status', error::STATUS_OBSOLETE);
+        $error->save();
+
+        // Test counts.
+        $this->assertEquals(2, error_service::get_error_count_by_status(error::STATUS_FAILED));
+        $this->assertEquals(1, error_service::get_error_count_by_status(error::STATUS_OBSOLETE));
+    }
+
+    /**
+     * Test record_batch_error method.
+     */
+    public function test_record_batch_error(): void {
+        global $DB;
+
+        $message = 'Batch processing failed';
+        $payload = '{"index":{"_index":"test_index","_id":"doc1"}}
+{"id":"doc1","itemid":123,"areaid":"test_area","contextid":456,"modified":1234567890}
+{"index":{"_index":"test_index","_id":"doc2"}}
+{"id":"doc2","itemid":124,"areaid":"test_area2","contextid":457,"modified":1234567891}';
+
+        error_service::record_batch_error($message, $payload);
+        $this->assertdebuggingcalledcount(2);
+
+        // Check that errors were created for both documents.
+        $errors = $DB->get_records('search_elastic_errors');
+        $this->assertCount(2, $errors);
+
+        foreach ($errors as $error) {
+            $this->assertStringContainsString($message, $error->errormessage);
+            $this->assertEquals(error::TYPE_INDEXING, $error->errortype);
+            $this->assertEquals(error::STATUS_FAILED, $error->status);
+        }
+    }
+
+    /**
+     * Test record_document_error method.
+     */
+    public function test_record_document_error(): void {
+        global $DB;
+
+        $message = 'Document indexing failed';
+        $docdata = [
+            'id' => 'test_doc_456',
+            'itemid' => 789,
+            'areaid' => 'test_area',
+            'contextid' => $this->coursecontext->id,
+            'modified' => time(),
+        ];
+
+        error_service::record_document_error($message, $docdata);
+        $this->assertDebuggingCalled('Document indexing failed');
+
+        $errors = $DB->get_records('search_elastic_errors');
+        $this->assertCount(1, $errors);
+
+        $error = reset($errors);
+        $this->assertEquals('test_doc_456', $error->docid);
+        $this->assertEquals(789, $error->itemid);
+        $this->assertEquals($this->coursecontext->id, $error->contextid);
+        $this->assertEquals('test_area', $error->areaid);
+        $this->assertEquals(error::TYPE_INDEXING, $error->errortype);
+        $this->assertStringContainsString($message, $error->errormessage);
+    }
+
+    /**
+     * Test record_document_error method with null docdata.
+     */
+    public function test_record_document_error_null_docdata(): void {
+        global $DB;
+
+        $message = 'Document indexing failed';
+        error_service::record_document_error($message, null);
+
+        // Should not create any errors when docdata is null.
+        $this->assertEquals(0, $DB->count_records('search_elastic_errors'));
+    }
+
+    /**
+     * Test record_tika_error method.
+     */
+    public function test_record_tika_error(): void {
+        global $DB;
+
+        // Create a test file.
+        $file = $this->create_test_file();
+        $message = 'Tika processing failed';
+
+        error_service::record_tika_error($file, $message);
+        $this->assertdebuggingcalledcount(1);
+
+        $errors = $DB->get_records('search_elastic_errors');
+        $this->assertCount(1, $errors);
+
+        $error = reset($errors);
+        $this->assertEquals($file->get_id(), $error->docid);
+        $this->assertEquals($file->get_itemid(), $error->itemid);
+        $this->assertEquals($file->get_contextid(), $error->contextid);
+        $this->assertEquals(error::TYPE_TIKA, $error->errortype);
+        $this->assertStringContainsString($message, $error->errormessage);
+        $this->assertStringContainsString($file->get_filename(), $error->errormessage);
+    }
+
+    /**
+     * Test retry_error method with non-existent error.
+     */
+    public function test_retry_error_not_found(): void {
+        $result = error_service::retry_error(999, false);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Unable to find error ID: 999', $result['message']);
+    }
+
+    /**
+     * Test retry_error method with indexing error.
+     */
+    public function test_retry_error_indexing(): void {
+        // Create test content.
+        $rec = new stdClass();
+        $rec->content = "Test content for retry";
+        $rec->courseid = $this->course->id;
+        $record = $this->generator->create_record($rec);
+
+        // Create an indexing error.
+        $docdata = [
+            'id' => 'test_doc_retry',
+            'itemid' => $record->id,
+            'areaid' => 'core_mocksearch-mock_search_area',
+            'contextid' => $this->coursecontext->id,
+            'modified' => time(),
+        ];
+
+        error_service::record_document_error('Indexing failed', $docdata);
+        $this->assertDebuggingCalled('Indexing failed');
+
+        $error = error::get_record(['docid' => 'test_doc_retry']);
+        $this->assertNotEmpty($error);
+
+        // Since we can't easily mock the elasticsearch engine for a successful retry,
+        // this test will likely fail the retry but we can test the process.
+        $result = error_service::retry_error($error->get('id'), false);
+
+        // The retry should have been attempted.
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('success', $result);
+        $this->assertArrayHasKey('message', $result);
+    }
+
+    /**
+     * Test extract_document_info method (via record_document_error).
+     */
+    public function test_extract_document_info(): void {
+        global $DB;
+
+        // Test with complete docdata.
+        $docdata = [
+            'id' => 'complete_doc',
+            'itemid' => 123,
+            'areaid' => 'test_area',
+            'contextid' => 456,
+            'modified' => 1234567890,
+        ];
+
+        error_service::record_document_error('Test message', $docdata);
+        $this->assertDebuggingCalled('Test message');
+
+        $error = $DB->get_record('search_elastic_errors', ['docid' => 'complete_doc']);
+        $this->assertNotEmpty($error);
+        $this->assertEquals(123, $error->itemid);
+        $this->assertEquals('test_area', $error->areaid);
+        $this->assertEquals(456, $error->contextid);
+        $this->assertEquals(1234567890, $error->contentmodified);
+    }
+
+    /**
+     * Test extract_document_info method with partial docdata.
+     */
+    public function test_extract_document_info_partial(): void {
+        global $DB;
+
+        // Test with partial docdata with missing itemid, contextid, modified.
+        $docdata = [
+            'id' => 'partial_doc',
+            'areaid' => 'test_area',
+        ];
+
+        error_service::record_document_error('Test message', $docdata);
+        $this->assertDebuggingCalled('Test message');
+
+        $select = $DB->sql_compare_text('docid') . ' = :docid';
+
+        $errors = error::get_records_select($select, ['docid' => 'partial_doc']);
+
+        $error = reset($errors);
+        $this->assertNotEmpty($error);
+        $this->assertEquals(0, $error->get('itemid'));
+        $this->assertEquals('test_area', $error->get('areaid'));
+        $this->assertNull($error->get('contextid'));
+        $this->assertNull($error->get('contentmodified'));
+    }
+
+    /**
+     * Test get_file_areaid method (via record_tika_error).
+     */
+    public function test_get_file_areaid(): void {
+        global $DB;
+
+        $file = $this->create_test_file();
+        error_service::record_tika_error($file, 'Test message');
+        $this->assertdebuggingcalledcount(1);
+
+        $error = $DB->get_record('search_elastic_errors', ['docid' => $file->get_id()]);
+        $this->assertNotEmpty($error);
+
+        // Should contain component and filearea in the areaid.
+        $this->assertStringContainsString($file->get_component(), $error->areaid);
+        $this->assertStringContainsString($file->get_filearea(), $error->areaid);
+    }
+
+    /**
+     * Test error status transitions.
+     */
+    public function test_error_status_transitions(): void {
+        // Create an error.
+        error_service::save_error('status_test', 123, $this->coursecontext->id, 'test_area', error::TYPE_INDEXING, 'Test');
+
+        $error = error::get_record(['docid' => 'status_test']);
+        $this->assertEquals(error::STATUS_FAILED, $error->get('status'));
+
+        // Mark as retrying.
+        $error->mark_retrying();
+        $error = error::get_record(['docid' => 'status_test']);
+        $this->assertEquals(error::STATUS_RETRYING, $error->get('status'));
+
+        // Delete the error record once it's successfully re-indexed.
+        $error->delete();
+        $error = error::get_record(['docid' => 'status_test']);
+        $this->assertFalse($error);
+    }
+
+    /**
+     * Test error retry count increment.
+     */
+    public function test_error_retry_count_increment(): void {
+        error_service::save_error('retry_test', 123, $this->coursecontext->id, 'test_area', error::TYPE_INDEXING, 'Test');
+
+        $error = error::get_record(['docid' => 'retry_test']);
+        $this->assertEquals(0, $error->get('retrycount'));
+
+        // Increment retry count.
+        $error->increment_retry();
+        $error = error::get_record(['docid' => 'retry_test']);
+        $this->assertEquals(1, $error->get('retrycount'));
+        $this->assertEquals(error::STATUS_FAILED, $error->get('status'));
+    }
+
+    /**
+     * Test malformed JSON payload in record_batch_error.
+     */
+    public function test_record_batch_error_malformed_json(): void {
+        global $DB;
+
+        $message = 'Batch processing failed';
+        $payload = 'invalid json payload';
+
+        error_service::record_batch_error($message, $payload);
+
+        // Should not create any errors with malformed JSON.
+        $this->assertEquals(0, $DB->count_records('search_elastic_errors'));
+    }
+
+    /**
+     * Test empty payload in record_batch_error.
+     */
+    public function test_record_batch_error_empty_payload(): void {
+        global $DB;
+
+        $message = 'Batch processing failed';
+        $payload = '';
+
+        error_service::record_batch_error($message, $payload);
+
+        // Should not create any errors with empty payload.
+        $this->assertEquals(0, $DB->count_records('search_elastic_errors'));
+    }
+
+    /**
+     * Helper method to create a test file.
+     */
+    private function create_test_file(): stored_file {
+        $fs = get_file_storage();
+        $filerecord = [
+            'contextid' => $this->coursecontext->id,
+            'component' => 'mod_assign',
+            'filearea' => 'submission_files',
+            'itemid' => 123,
+            'filepath' => '/',
+            'filename' => 'test.txt',
+            'userid' => 2,
+        ];
+
+        return $fs->create_file_from_string($filerecord, 'Test file content');
+    }
+
+    /**
+     * Data provider for different error types.
+     */
+    public static function error_type_provider(): array {
+        return [
+            'indexing' => [error::TYPE_INDEXING],
+            'tika' => [error::TYPE_TIKA],
+        ];
+    }
+
+    /**
+     * Test save_error with different error types.
+     *
+     * @dataProvider error_type_provider
+     * @param string $errortype
+     */
+    public function test_save_error_different_types($errortype): void {
+        global $DB;
+
+        error_service::save_error('type_test', 123, $this->coursecontext->id, 'test_area', $errortype, 'Test message');
+
+        $error = $DB->get_record('search_elastic_errors', ['docid' => 'type_test']);
+        $this->assertNotEmpty($error);
+        $this->assertEquals($errortype, $error->errortype);
+    }
+
+    /**
+     * Data provider for different error statuses.
+     */
+    public static function error_status_provider(): array {
+        return [
+            'retrying' => [error::STATUS_RETRYING],
+            'failed' => [error::STATUS_FAILED],
+            'obsolete' => [error::STATUS_OBSOLETE],
+        ];
+    }
+
+    /**
+     * Test get_error_count_by_status with different statuses.
+     *
+     * @dataProvider error_status_provider
+     * @param string $status
+     */
+    public function test_get_error_count_different_statuses($status): void {
+        // Create error and set specific status.
+        error_service::save_error('status_count_test', 123, $this->coursecontext->id, 'test_area', error::TYPE_INDEXING, 'Test');
+
+        $error = error::get_record(['docid' => 'status_count_test']);
+        $error->set('status', $status);
+        $error->save();
+
+        $count = error_service::get_error_count_by_status($status);
+        $this->assertEquals(1, $count);
+
+        // Test other statuses should return 0.
+        $otherstatus = $status === error::STATUS_FAILED ? error::STATUS_OBSOLETE : error::STATUS_FAILED;
+        $othercount = error_service::get_error_count_by_status($otherstatus);
+        $this->assertEquals(0, $othercount);
+    }
+
+    public function tearDown(): void {
+        parent::tearDown();
+        if ($this->generator) {
+            $this->generator->teardown();
+            $this->generator = null;
+        }
+    }
+}

--- a/tests/parse_payload_documents_test.php
+++ b/tests/parse_payload_documents_test.php
@@ -1,0 +1,253 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace search_elastic;
+
+use advanced_testcase;
+use context_system;
+use ReflectionMethod;
+use ReflectionProperty;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/search/engine/elastic/tests/fixtures/testable_engine.php');
+
+/**
+ * Test for parse_payload_documents method in engine class.
+ *
+ * @package     search_elastic
+ * @copyright   2025 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers      \search_elastic\engine::parse_payload_documents
+ */
+final class parse_payload_documents_test extends advanced_testcase {
+
+    /** @var Instance of testable_engine. */
+    protected $engine = null;
+
+    /** @var ReflectionMethod */
+    protected $method;
+
+    /**
+     * Setup testcase.
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+
+        set_config('hostname', 'http://localhost', 'search_elastic');
+        set_config('port', '9200', 'search_elastic');
+        set_config('index', 'test_index', 'search_elastic');
+
+        $this->engine = new testable_engine();
+
+        $this->method = new ReflectionMethod('\search_elastic\engine', 'parse_payload_documents');
+        $this->method->setAccessible(true);
+    }
+
+    /**
+     * Helper method to set payload and invoke parse_payload_documents.
+     *
+     * @param  string $payload
+     * @return array The result of parse_payload_documents
+     */
+    private function invoke_parse_payload_documents(string $payload): array {
+        $payloadproperty = new ReflectionProperty('\search_elastic\engine', 'payload');
+        $payloadproperty->setAccessible(true);
+        $payloadproperty->setValue($this->engine, $payload);
+
+        return $this->method->invoke($this->engine);
+    }
+
+    /**
+     * Test parse_payload_documents with empty payload.
+     */
+    public function test_parse_payload_documents_empty_payload(): void {
+        $result = $this->invoke_parse_payload_documents('');
+        $this->assertEquals([], $result);
+    }
+
+    /**
+     * Test parse_payload_documents with valid single document.
+     */
+    public function test_parse_payload_documents_single_document(): void {
+        $metadata = [
+            '_index' => 'test_index',
+            '_type' => 'doc',
+            '_id' => 'mod_assign-activity-37',
+        ];
+        $docdata = [
+            'areaid' => 'mod_assign-activity',
+            'id' => 'mod_assign-activity-37',
+            'itemid' => 37,
+            'title' => 'Assignment 1',
+            'content' => 'Test assign 1',
+            'contextid' => '353',
+            'courseid' => '8',
+            'owneruserid' => '0',
+            'modified' => '1753265148',
+            'type' => 1,
+            'parentid' => 'mod_assign-activity-37',
+        ];
+
+        $jsonmeta = json_encode($metadata);
+        $jsondoc = json_encode($docdata);
+        $payload = $jsonmeta . "\n" . $jsondoc. "\n";
+
+        $result = $this->invoke_parse_payload_documents($payload);
+        $this->assertCount(1, $result);
+        $this->assertEquals('mod_assign-activity-37', $result[0]['id']);
+        $this->assertEquals(37, $result[0]['itemid']);
+        $this->assertEquals(353, $result[0]['contextid']);
+        $this->assertEquals('mod_assign-activity', $result[0]['areaid']);
+        $this->assertEquals('1753265148', $result[0]['modified']);
+    }
+
+    /**
+     * Test parse_payload_documents with valid multiple documents.
+     */
+    public function test_parse_payload_documents_multiple_documents(): void {
+        $payload = file_get_contents(__DIR__ . '/fixtures/test_payload.json');
+        $result = $this->invoke_parse_payload_documents($payload);
+
+        // Verify it has 4 documents parsed.
+        $this->assertCount(4, $result);
+
+        // Test the first document (folder activity).
+        $this->assertEquals('mod_folder-activity-6', $result[0]['id']);
+        $this->assertEquals(6, $result[0]['itemid']);
+        $this->assertEquals(418, $result[0]['contextid']);
+        $this->assertEquals('mod_folder-activity', $result[0]['areaid']);
+        $this->assertEquals('1753319565', $result[0]['modified']);
+
+        // Test the second document (test1.pdf file).
+        $this->assertEquals('588', $result[1]['id']);
+        $this->assertEquals(6, $result[1]['itemid']);
+        $this->assertEquals(418, $result[1]['contextid']);
+        $this->assertEquals('mod_folder-activity', $result[1]['areaid']);
+        $this->assertEquals('1753319565', $result[1]['modified']);
+
+        // Test the third document (test2.pdf file).
+        $this->assertEquals('590', $result[2]['id']);
+        $this->assertEquals(6, $result[2]['itemid']);
+        $this->assertEquals(418, $result[2]['contextid']);
+        $this->assertEquals('mod_folder-activity', $result[2]['areaid']);
+        $this->assertEquals('1753319565', $result[2]['modified']);
+
+        // Test the fourth document (test3.pdf file).
+        $this->assertEquals('591', $result[3]['id']);
+        $this->assertEquals(6, $result[3]['itemid']);
+        $this->assertEquals(418, $result[3]['contextid']);
+        $this->assertEquals('mod_folder-activity', $result[3]['areaid']);
+        $this->assertEquals('1753319565', $result[3]['modified']);
+    }
+
+    /**
+     * Test parse_payload_documents index alignment with multiple documents.
+     */
+    public function test_parse_payload_documents_index_alignment(): void {
+        $payload = file_get_contents(__DIR__ . '/fixtures/test_payload.json');
+        $result = $this->invoke_parse_payload_documents($payload);
+
+        // Test that document IDs from metadata match document data at each index.
+        // This is important for the error handling where we match Elasticsearch response
+        // items to our parsed documents by index position.
+        $expectedmapping = [
+            0 => 'mod_folder-activity-6',
+            1 => '588',
+            2 => '590',
+            3 => '591',
+        ];
+
+        foreach ($expectedmapping as $index => $expectedid) {
+            $this->assertEquals($expectedid, $result[$index]['metadata']['index']['_id'],
+                "Metadata ID at index $index should match expected");
+            $this->assertEquals($expectedid, $result[$index]['id'],
+                "Extracted ID at index $index should match expected");
+        }
+    }
+
+    /**
+     * Test parse_payload_documents with missing fields.
+     */
+    public function test_parse_payload_documents_missing_fields(): void {
+        $payload = <<<'PAYLOAD'
+        {"index":{"_index":"test_index","_type":"doc","_id":"doc1"}}
+{"id":"doc1"}
+PAYLOAD;
+
+        $result = $this->invoke_parse_payload_documents($payload);
+        $this->assertCount(1, $result);
+        $this->assertEquals('doc1', $result[0]['id']);
+        $this->assertEquals(0, $result[0]['itemid']);
+        $this->assertEquals('unknown', $result[0]['areaid']);
+        $this->assertEquals(context_system::instance(), $result[0]['contextid']);
+        $this->assertNull($result[0]['modified']);
+    }
+
+    /**
+     * Test parse_payload_documents with malformed JSON document data.
+     */
+    public function test_parse_payload_documents_malformed_document(): void {
+        $payload = <<<'PAYLOAD'
+            {"index":{"_index":"test_index","_type":"doc","_id":"doc1"}}
+    {invalid JSON}
+    PAYLOAD;
+
+        $result = $this->invoke_parse_payload_documents($payload);
+        $this->assertCount(1, $result);
+        $this->assertNull($result[0]);
+    }
+
+    /**
+     * Test parse_payload_documents with mixed valid and invalid documents.
+     */
+    public function test_parse_payload_documents_mixed_valid_with_invalid(): void {
+        $payload = file_get_contents(__DIR__ . '/fixtures/mixed_valid_invalid_payload.json');
+        $result = $this->invoke_parse_payload_documents($payload);
+        $this->assertCount(4, $result);
+
+        // First document should be valid.
+        $this->assertEquals('mod_folder-activity-1', $result[0]['id']);
+        $this->assertEquals(1, $result[0]['itemid']);
+        $this->assertEquals('mod_folder-activity', $result[0]['areaid']);
+        $this->assertEquals(100, $result[0]['contextid']);
+        $this->assertEquals('1753319565', $result[0]['modified']);
+
+        // Second document should be null due to invalid metadata.
+        $this->assertNull($result[1]);
+
+        // Third document should be valid.
+        $this->assertEquals('mod_folder-activity-2', $result[2]['id']);
+        $this->assertEquals(3, $result[2]['itemid']);
+        $this->assertEquals('mod_folder-activity', $result[2]['areaid']);
+        $this->assertEquals(120, $result[2]['contextid']);
+        $this->assertEquals('1753319565', $result[2]['modified']);
+
+        // Fourth document should be null due to invalid docdata.
+        $this->assertNull($result[3]);
+    }
+
+    /**
+     * Test tearDown.
+     */
+    public function tearDown(): void {
+        parent::tearDown();
+        $this->engine = null;
+        $this->method = null;
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025051400;
+$plugin->version   = 2025062708;
 $plugin->release   = '4.2.6 (Build: 20250514)'; // Build same as version.
 $plugin->requires  = 2023042405;
 $plugin->component = 'search_elastic';


### PR DESCRIPTION
# Summary

Currently when search indexing fails, the scheduled task still reports success even though documents didn't actually get indexed. The errors just get logged to debug output and that's it. There's no way for admins to know that indexing is failing, and no way to retry the failed operations. Over time, the search index becomes stale because content that should be searchable just isn't there.

This is actually a core Moodle issue that affects all search engines, reported as [MDL-85876](https://moodle.atlassian.net/browse/MDL-85876). The problem is in the search framework itself, but we need a solution for Elasticsearch while we wait for core to fix it.

This patch adds an error tracking and retry system specifically for the Elasticsearch plugin. When indexing operations fail, they get recorded in a new database table with all the context needed to understand what went wrong. Admins can then see all the failures in a management interface and retry them either individually or in bulk.
The system handles three types of errors: regular document indexing failures, batch operation failures, and file processing errors (when Tika can't extract content from files). For file errors, it tracks the parent document ID so it can properly re-index the file content when retrying.

<img width="2494" height="3089" alt="image" src="https://github.com/user-attachments/assets/ce17f2e1-2e41-44e2-965d-46ae46fe9455" />


# Testing Instructions

## Prerequisites

### Test Environment Setup

- Moodle installation with Elasticsearch plugin
- Elasticsearch 6.8 running and accessible
- Tika server configured

Follow the README instructions to setup Elasticsearch and Apache Tika

### Test Data Preparation
1. Create test courses with various content types
2. Add test activity modules
3. Upload test files of different formats
4. Ensure initial indexing works correctly


## Generating an indexing failure scenario

1. Create configuration conflict by:
Adding an index with "_doc" mapping in Elasticsearch
```
PUT /moodle/_doc/1
{
  "title": "Hello world"  
}
```

<img width="2280" height="354" alt="kibana_1" src="https://github.com/user-attachments/assets/2962249c-3260-4084-839f-f1e8e53fd7c1" />


2. Confirm the record in Elasticsearch has a _doc mapping

<img width="1610" height="533" alt="kibana_2" src="https://github.com/user-attachments/assets/9b76e0d1-e04d-48c6-bd71-a7384f61c401" />


3. Set the index to `moodle` in `Site administration > Plugins > Search > Elastic > Plugin settings > Basic settings > Index`

4. Set your debugging level to `DEBUG_NORMAL`

5. Run the `core\task\search_index_task` scheduled task

6. Observe task consistently reports "success" despite all documents being rejected

7. Confirm that you only have 1 record in the moodle index
```
GET /moodle/_count
```

## Test error reporting for document indexing failures and batch operation errors

1. Navigate to Site administration > Plugins > Search > Elastic > Plugin settings > Indexing errors
2. Verify errors are recorded:
- Error type: Indexing
- Status: Failed
- Error messages mention the failures
- Document IDs and search areas are populated

## Test Tika file processing errors
1. Delete the broken `moodle_testing` index
2. Navigate to Site administration > Plugins > Search > Elastic > Plugin settings > Data enrichment settings
3. Temporarily set the `Maximum file size` to a low value (e.g. 10)
4. Run the core\task\search_index_task scheduled task
5. Verify errors are recorded:
- Error type: Tika
- Status: Failed
- Error messages mention the file name and details
- Parent ID populated

## Test individual error retry
1. Click "Retry" button next to a pending error
2. If the error type is Tika, it will queue and adhoc task if the file is larger than 1MB, otherwise it will re-index directly
3. Verify notification appears
4. Verify the record will be removed from the `mdl_search_elastic_errors` table upon successful retry

## Test Retry all errors
1. Click the "Retry All Errors" button
2. Verify it will queue and adhoc task
3. Once the adhoc task finished
4. Confirm successfully indexed records are removed from the `mdl_search_elastic_errors` table

Resolves: #138 