### PR TITLE
[#142] Add automatic retry logic for 413 Request Entity Too Large errors

### DIFF
--- a/classes/engine.php
+++ b/classes/engine.php
@@ -32,6 +32,7 @@
 namespace search_elastic;
 
 use search_elastic\local\service\error_service;
+use stdClass;
 
 /**
  * Elasticsearch engine.
@@ -620,72 +621,134 @@ class engine extends \core_search\engine {
         // If we don't have enough data to send yet return early.
         if ($this->payloadsize < $this->config->sendsize && !$sendnow) {
             return $numdocsignored;
-        } else if ($this->payloadsize > 0) { // Make sure we have at least some data to send.
-            $url = $this->get_url();
-            $client = new \search_elastic\esrequest();
-            $docurl = $url . '/' . $this->config->index . '/_bulk';
-            $response = $client->post($docurl, $this->payload);
-            $responsebody = json_decode($response->getBody());
+        }
 
-            // Process response.
-            // If no errors were returned from bulk operation then numdocs = numrecords.
-            // If there are errors we need to iterate through he response and count how many.
-            if ($response->getStatusCode() == 413) {
-                // TODO: add handling to retry sending payload one record at a time.
-                $message = get_string('addfail', 'search_elastic') . ' Request Entity Too Large';
-                error_service::record_batch_error($message, $this->payload);
-                $numdocsignored = $this->count;
-            } else if ($response->getStatusCode() >= 300) {
-                $message = get_string('addfail', 'search_elastic') . ' Error Code: ' . $response->getStatusCode();
-                error_service::record_batch_error($message, $this->payload);
-                $numdocsignored = $this->count;
-            } else if (isset($responsebody->errors) && $responsebody->errors) {
-                $payloaddocs = $this->parse_payload_documents();
+        // Make sure we have at least some data to send.
+        if ($this->payloadsize <= 0) {
+            return $numdocsignored;
+        }
 
-                if (isset($responsebody->items) && is_array($responsebody->items)) {
-                    foreach ($responsebody->items as $responseindex => $item) {
-                        if (isset($item->index->status) && $item->index->status >= 300) {
-                            $errortype = $item->index->error->type ?? 'unknown';
-                            $errorreason = $item->index->error->reason ?? 'unknown';
+        // Send the bulk request.
+        $url = $this->get_url();
+        $client = new \search_elastic\esrequest();
+        $docurl = $url . '/' . $this->config->index . '/_bulk';
+        $response = $client->post($docurl, $this->payload);
+        $responsebody = json_decode($response->getBody());
+        $statuscode = $response->getStatusCode();
 
-                            $message = get_string('addfail', 'search_elastic') .
-                                    ' Error Type: ' . $errortype .
-                                    ' Error Reason: ' . $errorreason;
+        // Handle different response scenarios.
+        if ($statuscode == 413) {
+            $numdocsignored = $this->handle_413_retry();
+        } else if ($statuscode >= 300) {
+            $message = get_string('addfail', 'search_elastic') . ' Error Code: ' . $statuscode;
+            error_service::record_batch_error($message, $this->payload);
+            $numdocsignored = $this->count;
+        } else if (isset($responsebody->errors) && $responsebody->errors) {
+            $numdocsignored = $this->log_bulk_response_item_errors($responsebody);
+        }
 
-                            // Get corresponding document data using the same index.
-                            $docdata = null;
-                            if (isset($payloaddocs[$responseindex]) && is_array($payloaddocs[$responseindex])) {
-                                $candidatedoc = $payloaddocs[$responseindex];
+        // Reset the counts.
+        $this->payload = false;
+        $this->payloadsize = 0;
 
-                                // Verify document ID matches to ensure we have the right document.
-                                $expectedid = $item->index->_id ?? null;
-                                $parsedid = $candidatedoc['id'] ?? null;
+        // Reset the parent doc count after attempting to add.
+        if ($isdoc) {
+            $this->count = 0;
+        }
 
-                                if ($expectedid && $parsedid && $expectedid === $parsedid) {
-                                    $docdata = $candidatedoc;
-                                } else {
-                                    // Log mismatch for debugging but continue with error recording.
-                                    debugging('Document ID mismatch at index ' . $responseindex . ': expected ' .
-                                        $expectedid . ', got ' . $parsedid, DEBUG_DEVELOPER);
-                                }
-                            }
+        return $numdocsignored;
+    }
 
-                            error_service::record_document_error($message, $docdata);
-                            $numdocsignored++;
-                        }
-                    }
+    /**
+     * Handle 413 payload too large error by retrying documents individually.
+     *
+     * @return int Number of documents ignored/failed.
+     */
+    private function handle_413_retry(): int {
+        // Retry sending payload one record at a time.
+        $payloaddocs = $this->parse_payload_documents();
+        $retryignored = 0;
+        $maxsize = (int)$this->config->sendsize;
+
+        foreach ($payloaddocs as $doc) {
+            if (is_null($doc)) {
+                $retryignored++;
+                continue;
+            }
+
+            // Check if individual document is too large.
+            $docsize = strlen(json_encode($doc));
+            if ($docsize > $maxsize) {
+                $retryignored++;
+                $message = get_string('addfail', 'search_elastic') .
+                    " Document too large ($docsize bytes exceeds $maxsize bytes limit). Doc ID: ({$doc['id']})";
+                error_service::record_document_error($message, $doc);
+                continue;
+            }
+
+            if (!$this->index_single_document($doc)) {
+                $retryignored++;
+                $message = get_string('addfail', 'search_elastic') .
+                    " Failed on individual retry after 413. Doc ID: ({$doc['id']})";
+                error_service::record_document_error($message, $doc);
+            }
+        }
+
+        unset($payloaddocs);
+
+        return $retryignored;
+    }
+
+    /**
+     * Log bulk response individual item errors.
+     *
+     * @param stdClass $responsebody
+     * @return int Number of documents that failed.
+     */
+    private function log_bulk_response_item_errors(stdClass $responsebody): int {
+        $payloaddocs = $this->parse_payload_documents();
+        $numdocsignored = 0;
+
+        if (!isset($responsebody->items) || !is_array($responsebody->items)) {
+            unset($payloaddocs);
+            return $numdocsignored;
+        }
+
+        foreach ($responsebody->items as $responseindex => $item) {
+            if (!isset($item->index->status) || $item->index->status < 300) {
+                continue;
+            }
+
+            $errortype = $item->index->error->type ?? 'unknown';
+            $errorreason = $item->index->error->reason ?? 'unknown';
+
+            $message = get_string('addfail', 'search_elastic') .
+                ' Error Type: ' . $errortype .
+                ' Error Reason: ' . $errorreason;
+
+            // Get corresponding document data using the same index.
+            $docdata = null;
+            if (isset($payloaddocs[$responseindex]) && is_array($payloaddocs[$responseindex])) {
+                $candidatedoc = $payloaddocs[$responseindex];
+
+                // Verify document ID matches to ensure we have the right document.
+                $expectedid = $item->index->_id ?? null;
+                $parsedid = $candidatedoc['id'] ?? null;
+
+                if ($expectedid && $parsedid && $expectedid === $parsedid) {
+                    $docdata = $candidatedoc;
+                } else {
+                    // Log mismatch for debugging but continue with error recording.
+                    debugging('Document ID mismatch at index ' . $responseindex . ': expected ' .
+                        $expectedid . ', got ' . $parsedid, DEBUG_DEVELOPER);
                 }
             }
 
-            // Reser the counts.
-            $this->payload = false;
-            $this->payloadsize = 0;
-
-            // Reset the parent doc count after attempting to add.
-            if ($isdoc) {
-                $this->count = 0;
-            }
+            error_service::record_document_error($message, $docdata);
+            $numdocsignored++;
         }
+
+        unset($payloaddocs);
 
         return $numdocsignored;
     }
@@ -717,11 +780,16 @@ class engine extends \core_search\engine {
                 if ($metadata && $docdata) {
                     $documents[$docindex] = [
                         'metadata' => $metadata,
-                        'id' => $docdata['id'] ?? 'unknown',
-                        'contextid' => $docdata['contextid'] ?? \context_system::instance(),
-                        'areaid' => $docdata['areaid'] ?? 'unknown',
-                        'itemid' => $docdata['itemid'] ?? 0,
-                        'modified' => $docdata['modified'] ?? null,
+                        ...$docdata,
+                    ];
+
+                    // Add defaults for missing keys.
+                    $documents[$docindex] += [
+                        'id' => 'unknown',
+                        'contextid' => \context_system::instance(),
+                        'areaid' => 'unknown',
+                        'itemid' => 0,
+                        'modified' => null,
                     ];
                 }
             }
@@ -734,12 +802,12 @@ class engine extends \core_search\engine {
 
 
     /**
-     * Index a single file document.
+     * Index a single document.
      *
-     * @param array $filedocdata
+     * @param array $docdata
      * @return bool
      */
-    public function index_single_file_document($filedocdata): bool {
+    public function index_single_document(array $docdata): bool {
         try {
             $url = $this->get_url();
             $luceneversion = $this->get_es_lucene_version();
@@ -749,8 +817,8 @@ class engine extends \core_search\engine {
                 $docprefix = '';
             }
 
-            $docurl = $url . '/' . $this->config->index . '/' . $docprefix . 'doc/' . $filedocdata['id'];
-            $jsondoc = json_encode($filedocdata);
+            $docurl = $url . '/' . $this->config->index . '/' . $docprefix . 'doc/' . $docdata['id'];
+            $jsondoc = json_encode($docdata);
 
             $client = new \search_elastic\esrequest();
             $response = $client->post($docurl, $jsondoc);

--- a/classes/engine.php
+++ b/classes/engine.php
@@ -700,9 +700,9 @@ class engine extends \core_search\engine {
     }
 
     /**
-     * Log bulk response individual item errors.
+     * Matches failed items with original documents and records error details.
      *
-     * @param stdClass $responsebody
+     * @param stdClass $responsebody Decoded JSON response from bulk operation.
      * @return int Number of documents that failed.
      */
     private function log_bulk_response_item_errors(stdClass $responsebody): int {

--- a/classes/local/service/error_service.php
+++ b/classes/local/service/error_service.php
@@ -361,6 +361,7 @@ class error_service {
         try {
             $itemid = $error->get('itemid');
             $context = context::instance_by_id($error->get('contextid'));
+            $config = get_config('search_elastic');
 
             // Get the record from search area.
             $record = self::get_record_for_context($searcharea, $context, $itemid);
@@ -374,6 +375,19 @@ class error_service {
             if (!$document) {
                 $error->mark_failed();
                 return ['success' => false, 'message' => 'Search area could not create document from record'];
+            }
+
+            // Check document size before attempting to index.
+            $docdata = $document->export_for_engine();
+            $docsize = strlen(json_encode($docdata));
+            $maxsize = (int)$config->sendsize;
+            if ($docsize > $maxsize) {
+                // Can't index this document because it's too large.
+                $error->mark_failed();
+                return [
+                    'success' => false,
+                    'message' => "Document too large ($docsize) bytes exceeds $config->sendsize bytes limit).",
+                ];
             }
 
             // Index the parent document first.
@@ -397,10 +411,20 @@ class error_service {
             }
 
             $fileerrorcount = 0;
+            $filesskipped = 0;
 
             foreach ($files as $file) {
                 $filedocdata = $document->export_file_for_engine($file);
-                $success = $engine->index_single_file_document($filedocdata);
+
+                // Check file document size.
+                $filesize = strlen(json_encode($filedocdata));
+                if ($filesize > $config->sendsize) {
+                    $filesskipped++;
+                    debugging("Skipping file (too large): {$file->get_filename()} ($filesize bytes, exceeds $maxsize bytes limit)");
+                    continue;
+                }
+
+                $success = $engine->index_single_document($filedocdata);
                 if (!$success) {
                     $fileerrorcount++;
                 }
@@ -408,12 +432,22 @@ class error_service {
 
             if ($fileerrorcount == 0) {
                 return ['success' => true, 'message' => 'Content reindexed successfully'];
+            } else if ($filesskipped > 0 && $fileerrorcount == 0) {
+                return [
+                    'success' => true, 'message' => "Content reindexed $filesskipped file(s) skipped - too large",
+                ];
+            } else if ($filesskipped > 0 && $fileerrorcount > 0) {
+                $error->mark_failed();
+                return [
+                    'success' => false,
+                    'message' => "Failed to reindex some files. $filesskipped file(s) skipped (too large).",
+                ];
             }
 
             $error->mark_failed();
             return ['success' => false, 'message' => 'Failed to reindex content'];
         } catch (Exception $e) {
-            return ['success' => false, 'message' => 'Exception during retry: ' . $e->getMessage()];
+            return ['success' => false, 'message' => "Exception during retry: {$e->getMessage()}"];
         }
     }
 
@@ -503,7 +537,7 @@ class error_service {
             $filedocdata = $parentdocument->export_file_for_engine($file);
 
             // Index just this specific file document.
-            $success = $engine->index_single_file_document($filedocdata);
+            $success = $engine->index_single_document($filedocdata);
 
             if ($success) {
                 return ['success' => true, 'message' => 'File content extracted and indexed successfully'];

--- a/lang/en/search_elastic.php
+++ b/lang/en/search_elastic.php
@@ -23,7 +23,7 @@
  */
 
 $string['actions'] = 'Actions';
-$string['addfail'] = 'Failed to add document to index';
+$string['addfail'] = 'Failed to add document to index.';
 $string['adminsettings'] = 'Plugin settings';
 $string['advsettings'] = 'Advanced settings';
 $string['all'] = 'All';

--- a/tests/engine_test.php
+++ b/tests/engine_test.php
@@ -1141,4 +1141,273 @@ final class engine_test extends \advanced_testcase {
             $seenresults[] = $content;
         }
     }
+
+    /**
+     * Test handle_413_retry with all documents under size limit.
+     */
+    public function test_handle_413_retry_all_succeed(): void {
+        global $DB;
+
+        $docs = [
+            ['id' => 'doc1', 'content' => 'Content1', 'areaid' => 'test-area',
+                'contextid' => 1, 'itemid' => 1, 'modified' => time()],
+            ['id' => 'doc2', 'content' => 'Content2', 'areaid' => 'test-area',
+                'contextid' => 1, 'itemid' => 2, 'modified' => time()],
+        ];
+        $payload = $this->create_test_payload($docs);
+        $this->engine->set_test_payload($payload);
+
+        // Mock successful indexing.
+        $this->engine->set_mock_index_results([true, true]);
+
+        // Call the handler.
+        $ignored = $this->engine->test_handle_413_retry();
+
+        // Verify there are no errors.
+        $errors = $DB->count_records('search_elastic_errors');
+        $this->assertEquals(0, $ignored);
+        $this->assertEquals(0, $errors);
+    }
+
+    /**
+     * Test handle_413_retry with oversized document.
+     */
+    public function test_handle_413_retry_oversized_document(): void {
+        global $DB;
+
+        $config = get_config('search_elastic');
+        $maxsize = $config->sendsize ?? 9000000;
+
+        $docs = [
+            ['id' => 'doc1', 'content' => 'Small content', 'areaid' => 'test-area-413-oversized',
+                'contextid' => 1, 'itemid' => 1, 'modified' => time()],
+            ['id' => 'doc2', 'content' => str_repeat('Content', $maxsize + 100), 'areaid' => 'test-area-413-oversized',
+                'contextid' => 1, 'itemid' => 2, 'modified' => time()],
+        ];
+        $payload = $this->create_test_payload($docs);
+        $this->engine->set_test_payload($payload);
+
+        // Mock doc1 succeeds but doc2 won't be tried due to size.
+        $this->engine->set_mock_index_results([true]);
+
+        // Once document ignored (doc2).
+        $ignored = $this->engine->test_handle_413_retry();
+        $this->assertEquals(1, $ignored);
+        $this->assertDebuggingCalledCount(1);
+
+        // Verify error message mentions size.
+        $error = $DB->get_record('search_elastic_errors', ['areaid' => 'test-area-413-oversized']);
+        $this->assertStringContainsString('too large', strtolower($error->errormessage));
+        $this->assertStringContainsString('doc2', strtolower($error->errormessage));
+    }
+
+    /**
+     * Test handle_413_retry with failed retry.
+     */
+    public function test_handle_413_retry_individual_failure(): void {
+        global $DB;
+
+        $docs = [
+            ['id' => 'doc1', 'content' => 'Content1', 'areaid' => 'test-area-413-individual-retry-failure',
+                'contextid' => 1, 'itemid' => 1, 'modified' => time()],
+            ['id' => 'doc2', 'content' => 'Content2', 'areaid' => 'test-area-413-individual-retry-failure',
+                'contextid' => 1, 'itemid' => 2, 'modified' => time()],
+        ];
+        $payload = $this->create_test_payload($docs);
+        $this->engine->set_test_payload($payload);
+
+        // Mock doc1 succeeds but doc2 failed.
+        $this->engine->set_mock_index_results([true, false]);
+
+        $ignored = $this->engine->test_handle_413_retry();
+        $this->assertEquals(1, $ignored);
+        $this->assertDebuggingCalledCount(1);
+
+        // Verify error message mentions individual retry failure.
+        $error = $DB->get_record('search_elastic_errors', ['areaid' => 'test-area-413-individual-retry-failure']);
+        $this->assertStringContainsString('individual retry', strtolower($error->errormessage));
+        $this->assertStringContainsString('doc2', strtolower($error->errormessage));
+    }
+
+    /**
+     * Test handle_413_retry mixed scenarios.
+     */
+    public function test_handle_413_retry_mixed_scenarios(): void {
+        global $DB;
+
+        $config = get_config('search_elastic');
+        $maxsize = $config->sendsize ?? 9000000;
+
+        $docs = [
+            ['id' => 'doc1', 'content' => 'Content1', 'areaid' => 'test-area-413-mixed-scenarios',
+                'contextid' => 1, 'itemid' => 1, 'modified' => time()],
+            ['id' => 'doc2', 'content' => str_repeat('Content', $maxsize + 100), 'areaid' => 'test-area-413-mixed-scenarios',
+                'contextid' => 1, 'itemid' => 2, 'modified' => time()],
+            ['id' => 'doc3', 'content' => 'Content3', 'areaid' => 'test-area-413-mixed-scenarios',
+                'contextid' => 1, 'itemid' => 2, 'modified' => time()],
+        ];
+        $payload = $this->create_test_payload($docs);
+        $this->engine->set_test_payload($payload);
+
+        // Mock doc1 succeeds, doc2 skipped (oversized), doc 3 failed.
+        $this->engine->set_mock_index_results([true, false, false]);
+
+        // 2 documents ignored.
+        $ignored = $this->engine->test_handle_413_retry();
+        $this->assertEquals(2, $ignored);
+        $this->assertDebuggingCalledCount(2);
+
+        // 2 errors logged.
+        $errors = $DB->count_records('search_elastic_errors');
+        $this->assertEquals(2, $errors);
+    }
+
+    /**
+     * Test log_bulk_response_item_errors with all successful items.
+     */
+    public function test_log_bulk_response_item_errors_all_success(): void {
+        global $DB;
+
+        $docs = [
+            ['id' => 'doc1', 'content' => 'Content1', 'areaid' => 'test-area',
+                'contextid' => 1, 'itemid' => 1, 'modified' => time()],
+            ['id' => 'doc2', 'content' => 'Content2', 'areaid' => 'test-area',
+                'contextid' => 1, 'itemid' => 2, 'modified' => time()],
+        ];
+        $payload = $this->create_test_payload($docs);
+        $this->engine->set_test_payload($payload);
+
+        // Mock response with all successful items.
+        $responsebody = (object)[
+            'errors' => false,
+            'items' => [
+                (object)[
+                    'index' => (object)[
+                        '_id' => 'doc1',
+                        'status' => 201,
+                        'result' => 'created',
+                    ],
+                ],
+                (object)[
+                    'index' => (object)[
+                        '_id' => 'doc2',
+                        'status' => 201,
+                        'result' => 'created',
+                    ],
+                ],
+            ],
+        ];
+
+        // No documents ignored.
+        $ignored = $this->engine->test_log_bulk_response_item_errors($responsebody);
+        $this->assertEquals(0, $ignored);
+
+        // No errors.
+        $errors = $DB->count_records('search_elastic_errors');
+        $this->assertEquals(0, $errors);
+    }
+
+    /**
+     * Test log_bulk_response_item_errors with failures.
+     */
+    public function test_log_bulk_response_item_errors_with_failures(): void {
+        global $DB;
+
+        $docs = [
+            ['id' => 'doc1', 'content' => 'Content1', 'areaid' => 'test-area-bulk-item-fail',
+                'contextid' => 1, 'itemid' => 1, 'modified' => time()],
+            ['id' => 'doc2', 'content' => 'Content2', 'areaid' => 'test-area-bulk-item-fail',
+                'contextid' => 1, 'itemid' => 2, 'modified' => time()],
+        ];
+        $payload = $this->create_test_payload($docs);
+        $this->engine->set_test_payload($payload);
+
+        // Mock response with all successful items.
+        $responsebody = (object)[
+            'errors' => true,
+            'items' => [
+                (object)[
+                    'index' => (object)[
+                        '_id' => 'doc1',
+                        'status' => 429,
+                        'error' => (object)[
+                            'type' => 'some_exception',
+                            'reason' => 'Too Many Requests',
+                        ],
+                    ],
+                ],
+                (object)[
+                    'index' => (object)[
+                        '_id' => 'doc2',
+                        'status' => 201,
+                        'result' => 'created',
+                    ],
+                ],
+            ],
+        ];
+
+        // One document failed.
+        $ignored = $this->engine->test_log_bulk_response_item_errors($responsebody);
+        $this->assertEquals(1, $ignored);
+        $this->assertDebuggingCalledCount(1);
+
+        // Verify error details.
+        $error = $DB->get_record('search_elastic_errors', ['areaid' => 'test-area-bulk-item-fail']);
+        $this->assertStringContainsString('some_exception', strtolower($error->errormessage));
+        $this->assertStringContainsString('too many requests', strtolower($error->errormessage));
+    }
+
+    /**
+     * Test log_bulk_response_item_errors with document ID mismatch.
+     */
+    public function test_log_bulk_response_item_errors_id_mismatch(): void {
+        global $DB;
+
+        $docs = [
+            ['id' => 'doc1', 'content' => 'Content1', 'areaid' => 'test-area-id-mismatch',
+                'contextid' => 1, 'itemid' => 1, 'modified' => time()],
+        ];
+        $payload = $this->create_test_payload($docs);
+        $this->engine->set_test_payload($payload);
+
+        // Mock response with mismatched ID.
+        $responsebody = (object)[
+            'errors' => true,
+            'items' => [
+                (object)[
+                    'index' => (object)[
+                        '_id' => 'wrong-id',
+                        'status' => 400,
+                        'error' => (object)[
+                            'type' => 'test_error',
+                            'reason' => 'test reason',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $ignored = $this->engine->test_log_bulk_response_item_errors($responsebody);
+        $errors = $DB->count_records('search_elastic_errors');
+
+        // Error is not logged but debugging is called with mismatch.
+        $this->assertDebuggingCalled('Document ID mismatch at index 0: expected wrong-id, got doc1');
+        $this->assertEquals(1, $ignored);
+        $this->assertEquals(0, $errors);
+    }
+
+    /**
+     * Helper method to create a test payload from document arrays.
+     * @param array $docs
+     * @return string
+     */
+    private function create_test_payload(array $docs): string {
+        $config = get_config('search_elastic');
+        $payload = '';
+        foreach ($docs as $doc) {
+            $meta = ['index' => ['_index' => $config->index, '_id' => $doc['id']]];
+            $payload .= json_encode($meta) . "\n" . json_encode($doc) . "\n";
+        }
+        return $payload;
+    }
 }

--- a/tests/fixtures/testable_engine.php
+++ b/tests/fixtures/testable_engine.php
@@ -24,6 +24,8 @@
 
 namespace search_elastic;
 
+use stdClass;
+
 /**
  * Elasticsearch engine.
  *
@@ -32,6 +34,12 @@ namespace search_elastic;
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class testable_engine extends \search_elastic\engine {
+    /** @var array */
+    private array $mockindexresults = [];
+
+    /** @var int */
+    private int $mockindexcallcount = 0;
+
     /**
      *      * Function that lets us update the internally cached config object of the engine.
      * @param string $name
@@ -39,5 +47,61 @@ class testable_engine extends \search_elastic\engine {
      */
     public function test_set_config($name, $value) {
         $this->config->$name = $value;
+    }
+
+    /**
+     * Helper method to set the payload for testing.
+     * @param string $payload
+     */
+    public function set_test_payload(string $payload): void {
+        $this->payload = $payload;
+        $this->payloadsize = strlen($payload);
+    }
+
+    /**
+     * Helper method to set mock index results.
+     * @param array $results
+     */
+    public function set_mock_index_results(array $results): void {
+        $this->mockindexresults = $results;
+        $this->mockindexcallcount = 0;
+    }
+
+    /**
+     * Wrapper for testing handle_413_retry.
+     * @return int
+     */
+    public function test_handle_413_retry(): int {
+        $reflection = new \ReflectionClass($this);
+        $method = $reflection->getMethod('handle_413_retry');
+        $method->setAccessible(true);
+        return $method->invoke($this);
+    }
+
+    /**
+     * Wrapper for testing log_bulk_response_item_errors.
+     * @param stdClass $responsebody
+     * @return int
+     */
+    public function test_log_bulk_response_item_errors(stdClass $responsebody): int {
+        $reflection = new \ReflectionClass($this);
+        $method = $reflection->getMethod('log_bulk_response_item_errors');
+        $method->setAccessible(true);
+        return $method->invoke($this, $responsebody);
+    }
+
+    /**
+     * Wrapper for setting mock index results for index_single_document.
+     * @param array $docdata
+     * @return bool
+     */
+    public function index_single_document(array $docdata): bool {
+        if (!empty($this->mockindexresults)) {
+            $result = $this->mockindexresults[$this->mockindexcallcount] ?? true;
+            $this->mockindexcallcount++;
+            return $result;
+        }
+
+        return parent::index_single_document($docdata);
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025080100;
+$plugin->version   = 2025103100;
 $plugin->release   = '4.2.6 (Build: 20250514)'; // Build same as version.
 $plugin->requires  = 2023042405;
 $plugin->component = 'search_elastic';


### PR DESCRIPTION
# Summary

When Elasticsearch returns a 413 error, automatically retry documents individually instead of recording the entire batch as failed. 

Changes:
- Add 413 error handling in batch_add_documents()
- Updated parse_payload_documents() to extract individual documents from bulk payload
- Add size validation before individual retry to skip oversized documents
- Log individual document errors instead of batch errors for 413 responses
- Renamed index_single_file_document to index_single_document
- Refactor error handling into separate methods:
	- handle_413_retry(): Retry documents individually after 413
	- log_bulk_response_item_errors(): Logs Elasticsearch item-level errors
- Add unit  tests for 413 retry and log_bulk_response_item_errors

# Unit tests

The unit tests in this commit is inside the **engine_test.php**. However, the entire test file is skipped if Elasticsearch extenstion test server is not set. Please make sure to configure the test server to run and verify the additional unit tests are working as expected.

# Testing Instructions

## Prerequisites
### Test Environment Setup
Moodle installation with Elasticsearch plugin
Elasticsearch running and accessible
Tika server configured
Follow the README instructions to setup Elasticsearch and Apache Tika

## Test retry logic for 413 error
1. Create test courses with various content types
2. Create an assignment (or other module) and attach multiple large files with more than 10 MB of text content
3. Navigate to `Site administration > Plugins > Search > Elastic > Plugin settings > Basic settings > Request size (search_elastic | sendsize)` and set it to `9000000`. Some Elasticsearch providers such as AWS have a limit on how big the HTTP payload can be. We use this sendsize value to determine if your document is oversized.
4. Navigate to `Site administration > Server > Tasks > Scheduled task > Global search indexing (core\task\search_index_task)`
and run the indexer
5. Navigate to `Site administration > Plugins > Search > Elastic > Indexing errors`
6. Verify that oversized documents (files/documents that exceeds `9000000` bytes) are logged with size details in the report table.
7. Verify the indexed files are searchable
