### PR TITLE
Improve the connection check #110

### DIFF
--- a/classes/engine.php
+++ b/classes/engine.php
@@ -255,6 +255,7 @@ class engine extends \core_search\engine {
      * @return string|bool true if server is ready, else error string.
      */
     public function is_server_ready($stack = false) {
+        global $CFG;
         // Not configured yet.
         if (empty($this->get_url())) {
             return get_string('connection:na', 'search_elastic');
@@ -281,13 +282,17 @@ class engine extends \core_search\engine {
      */
     public function get_server_status_code($stack = false): int {
         $url = $this->get_url();
-        $client = new \search_elastic\esrequest($stack);
 
-        try {
-            $response = $client->get($url);
-            $responsecode = $response->getStatusCode();
-        } catch (\GuzzleHttp\Exception\ConnectException $e) {
-            return 503;
+        // Regardless the setting timeout, check timeout should be always 5.
+        $client = new \search_elastic\esrequest($stack, 5);
+        $responsecode = 503;
+        if ($url) {
+            try {
+                $response = $client->get($url);
+                $responsecode = $response->getStatusCode();
+            } catch (\GuzzleHttp\Exception\ConnectException $e) {
+                return 503;
+            }
         }
 
         return $responsecode;

--- a/classes/esrequest.php
+++ b/classes/esrequest.php
@@ -50,14 +50,16 @@ class esrequest {
      * Search engine availability should be checked separately.
      *
      * @param \GuzzleHttp\HandlerStack $handler Optional custom Guzzle handler stack
+     * @param int $timeout default connection timeout to override the timeout in the plugin setting.
+     * Often used in health check.
      * @return void
      */
-    public function __construct($handler = false) {
+    public function __construct($handler = false, $timeout = null) {
         $this->config = get_config('search_elastic');
         $this->signing = (isset($this->config->signing) ? (bool)$this->config->signing : false);
 
         $config = [
-            'timeout' => isset($this->config->timeout) ? intval($this->config->timeout) : 0,
+            'timeout' => $timeout != null ? $timeout : (isset($this->config->timeout) ? intval($this->config->timeout) : 0),
             'connect_timeout' => intval($this->config->connecttimeout),
         ];
 

--- a/lib.php
+++ b/lib.php
@@ -61,5 +61,12 @@ function search_elastic_extend_navigation_user() {
  * @return array
  */
 function search_elastic_status_checks(): array {
+    // If elastic isn't the selected engine or global search is off, do not register the check at all.
+    if (
+        !\core_search\manager::is_global_search_enabled() ||
+        (isset($CFG->searchengine) && $CFG->searchengine !== 'elastic')
+    ) {
+        return [];
+    }
     return [new \search_elastic\check\server_ready_check()];
 }

--- a/tests/engine_test.php
+++ b/tests/engine_test.php
@@ -152,12 +152,32 @@ final class engine_test extends \advanced_testcase {
     public static function is_server_ready_provider(): array {
         return [
           '200' => [
-            'code' => 200,
-            'ok' => true,
+              'code' => 200,
+              'ok' => true,
+              'host' => null,
+              'searchengine' => 'elastic',
+              'status' => true,
           ],
           '404' => [
-            'code' => 404,
-            'ok' => false,
+              'code' => 404,
+              'ok' => false,
+              'host' => null,
+              'searchengine' => 'elastic',
+              'status' => '404',
+          ],
+          '503' => [
+              'code' => 200,
+              'ok' => false,
+              'host' => '',
+              'searchengine' => 'elastic',
+              'status' => '503',
+          ],
+          'na' => [
+              'code' => 200,
+              'ok' => false,
+              'host' => '',
+              'searchengine' => 'other',
+              'status' => get_string('connection:na', 'search_elastic'),
           ],
         ];
     }
@@ -167,25 +187,38 @@ final class engine_test extends \advanced_testcase {
      *
      * @param int $code Simulated HTTP status code
      * @param bool $expectedok If the server should be expected to be ready/ok.
+     * @param string|null $host elastic host.
+     * @param string $searchengine Selected search engine.
+     * @param string|bool $expectedstatus Expected return status.
      * @dataProvider is_server_ready_provider
      */
-    public function test_is_server_ready(int $code, bool $expectedok): void {
+    public function test_is_server_ready(
+        int $code,
+        bool $expectedok,
+        string|null $host,
+        string $searchengine,
+        string|bool $expectedstatus
+    ): void {
         // Create a mock stack and queue a response.
         $mock = new MockHandler([
             new Response($code, ['Content-Type' => 'application/json']),
         ]);
+        if (isset($host)) {
+            set_config('hostname', '', 'search_elastic');
+        }
+        set_config('searchengine', $searchengine);
 
         $stack = HandlerStack::create($mock);
 
         $engine = new \search_elastic\engine();
-        $status = $engine->is_server_ready($stack);
+        $result = $engine->is_server_ready($stack);
 
         if ($expectedok) {
-            $this->assertTrue($status);
+            $this->assertTrue(is_bool($result));
+            $this->assertEquals($result, $expectedstatus);
         } else {
-            // Status should contain a string with the 404 code in it.
-            $this->assertTrue(is_string($status));
-            $this->assertTrue(strpos($status, '404') != false);
+            $this->assertTrue(is_string($result));
+            $this->assertTrue($result === $expectedstatus || strpos($result, $expectedstatus) != false);
         }
     }
 

--- a/tests/esrequest_test.php
+++ b/tests/esrequest_test.php
@@ -89,9 +89,8 @@ final class esrequest_test extends \advanced_testcase {
     }
 
     /**
-     * Test that exceptions don't get eaten when host is unreachable.
-     *
-     * @see https://github.com/catalyst/moodle-search_elastic/pull/119 PR #119 for why this matters.
+     * Test that unreachable host must return 503
+     * The GuzzleHttp exception is no longer be throwed
      */
     public function test_get_unreachable_host(): void {
         $this->expectException(\GuzzleHttp\Exception\ConnectException::class);

--- a/tests/fixtures/mock_search_area.php
+++ b/tests/fixtures/mock_search_area.php
@@ -21,7 +21,7 @@ namespace core_mocksearch\search;
  * Component implementing search for testing purposes.
  *
  * @package   search_elastic
- * @category  phpunit
+ * @category  test
  * @copyright David Monllao {@link http://www.davidmonllao.com}
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -44,6 +44,9 @@ class mock_boost_area extends \core_mocksearch\search\mock_search_area {
         return true;
     }
 
+    /**
+     * Mock get_recordset_by_timestamp.
+     */
     public function get_recordset_by_timestamp($modifiedfrom = 0) {
         global $DB;
 
@@ -71,6 +74,9 @@ class mock_boost_area extends \core_mocksearch\search\mock_search_area {
         return $docdata;
     }
 
+    /**
+     * Mock get_document.
+     */
     public function get_document($record, $options = []) {
         global $USER;
 
@@ -91,6 +97,9 @@ class mock_boost_area extends \core_mocksearch\search\mock_search_area {
         return $doc;
     }
 
+    /**
+     * Mock attach_files.
+     */
     public function attach_files($document) {
         global $DB;
 
@@ -104,10 +113,16 @@ class mock_boost_area extends \core_mocksearch\search\mock_search_area {
         }
     }
 
+    /**
+     * Mock uses_file_indexing.
+     */
     public function uses_file_indexing() {
         return true;
     }
 
+    /**
+     * Mock uses_file_indexing.
+     */
     public function check_access($id) {
         global $DB, $USER;
 
@@ -122,14 +137,23 @@ class mock_boost_area extends \core_mocksearch\search\mock_search_area {
         return \core_search\manager::ACCESS_DELETED;
     }
 
+    /**
+     * Mock get_doc_url.
+     */
     public function get_doc_url(\core_search\document $doc) {
         return new \moodle_url('/index.php');
     }
 
+    /**
+     * Mock get_context_url.
+     */
     public function get_context_url(\core_search\document $doc) {
         return new \moodle_url('/index.php');
     }
 
+    /**
+     * Mock get_visible_name.
+     */
     public function get_visible_name($lazyload = false) {
         return 'Mock search area';
     }


### PR DESCRIPTION
Improve the connection check #110
- If Elasticsearch is not the selected search engine, or Global Search is disabled, we do not register the health check.
- If Global Search is enabled and the search engine is set to Elasticsearch, return HTTP 503 when the host is empty.
- If Global Search is disabled or the search engine is not Elasticsearch, return a “Not configured” message (settings page only).
- Enforce a 5-second timeout for all health check requests.
- Update related UTs and fix CI complains