### PR TITLE
[#152] Remove pluginfile tokens

### DIFF
--- a/classes/document.php
+++ b/classes/document.php
@@ -153,6 +153,9 @@ class document extends \core_search\document {
      * @return string HTML text to be renderer
      */
     protected function format_text($text) {
+        // Remove @@PLUGINFILE@@ tokens and associated file paths from search snippets.
+        $text = preg_replace('/@@PLUGINFILE@@[^\s"\'<>\]]*/', '', $text);
+
         // Since we allow output for highlighting, we need to encode html entities.
         // This ensures plaintext html chars don't become valid html.
         $out = s($text);

--- a/tests/document_test.php
+++ b/tests/document_test.php
@@ -102,6 +102,42 @@ final class document_test extends \advanced_testcase {
     }
 
     /**
+     * Test that @@PLUGINFILE@@ tokens and associated file paths are stripped from text.
+     */
+    public function test_pluginfile_token_stripped(): void {
+        $text = 'some content with a file @@PLUGINFILE@@/path/to/file.jpg and some more text';
+        $expected = 'some content with a file  and some more text';
+
+        $builder = $this->getMockBuilder('\search_elastic\document');
+        $builder->disableOriginalConstructor();
+        $stub = $builder->getMock();
+
+        $method = new \ReflectionMethod('\search_elastic\document', 'format_text');
+        $method->setAccessible(true);
+        $proxy = $method->invoke($stub, $text);
+
+        $this->assertEquals($expected, $proxy);
+    }
+
+    /**
+     * Test that @@PLUGINFILE@@ with highlighting markers is handled correctly.
+     */
+    public function test_pluginfile_with_highlighting(): void {
+        $text = '@@PLUGINFILE@@/path/to/file.jpg @@HI_S@@search term@@HI_E@@ description';
+        $expected = ' <span class="highlight">search term</span> description';
+
+        $builder = $this->getMockBuilder('\search_elastic\document');
+        $builder->disableOriginalConstructor();
+        $stub = $builder->getMock();
+
+        $method = new \ReflectionMethod('\search_elastic\document', 'format_text');
+        $method->setAccessible(true);
+        $proxy = $method->invoke($stub, $text);
+
+        $this->assertEquals($expected, $proxy);
+    }
+
+    /**
      * Test getting enrichment processors.
      */
     public function test_get_enrichment_processors(): void {


### PR DESCRIPTION
Issue: #152 

This PR improves handling of `@@PLUGINFILE@@` tokens in search snippets and updates the associated PHPUnit tests.

Steps to reproduce and test:

1. Install a 4.5 Moodle locally

```
git clone -b MOODLE_405_STABLE git@github.com:moodle/moodle.git moodle405stable
cd $DOCKER_DEV_ROOT/sites/moodle405stable
git clean -ffd && git submodule sync && git submodule update --init --recursive --force --jobs 16
control add moodle405stable --db pgsql --php 8.3 --elasticsearch
control install moodle405stable --adminuser admin --adminpass admin
```

2. Install elastic search plugin https://github.com/mattporritt/moodle-search_elastic (MOODLE_404_STABLE)
3. Create a new course named "test"
4. Add a file to the course named "test", set description to "@@PLUGINFILE@@/image.png", select a random file
5. Save and display
6. Go to /admin/searchareas.php, reindex courses search area
7. Go to /admin/searchareas.php, reindex images search area
8. Go to /admin/tool/task/scheduledtasks.php, run "Global search indexing" task
9. Go to /search/index.php, search for "test". Obersve the warning
10. Update the moodle-search_elastic plugin to use the feature branch `owenherbert-catalyst:issue-152-fix`
11. Repeat step 9, observe the warning is gone.