### PR TITLE
[#155] Fix test_is_server_ready and add missing global in status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,4 @@ jobs:
       moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}
     with:
       disable_grunt: true
-      disable_phpcpd: true
       release_branches: MOODLE_404_STABLE

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -39,8 +39,8 @@ use core_privacy\local\request\userlist;
 class provider implements
     // This search engine plugin does not store any data itself.
     // It has no database tables, and it purely acts as a conduit, sending data externally.
-    \core_privacy\local\request\core_userlist_provider,
     \core_privacy\local\metadata\provider,
+    \core_privacy\local\request\core_userlist_provider,
     \core_privacy\local\request\plugin\provider {
     // This trait must be included to provide the relevant polyfill for the metadata provider.
     use \core_privacy\local\legacy_polyfill;

--- a/lib.php
+++ b/lib.php
@@ -61,6 +61,7 @@ function search_elastic_extend_navigation_user() {
  * @return array
  */
 function search_elastic_status_checks(): array {
+    global $CFG;
     // If elastic isn't the selected engine or global search is off, do not register the check at all.
     if (
         \core_search\manager::is_global_search_enabled() &&

--- a/tests/engine_test.php
+++ b/tests/engine_test.php
@@ -166,9 +166,9 @@ final class engine_test extends \advanced_testcase {
               'status' => '404',
           ],
           '503' => [
-              'code' => 200,
+              'code' => 503,
               'ok' => false,
-              'host' => '',
+              'host' => 'localhost',
               'searchengine' => 'elastic',
               'status' => '503',
           ],
@@ -204,7 +204,7 @@ final class engine_test extends \advanced_testcase {
             new Response($code, ['Content-Type' => 'application/json']),
         ]);
         if (isset($host)) {
-            set_config('hostname', '', 'search_elastic');
+            set_config('hostname', $host, 'search_elastic');
         }
         set_config('searchengine', $searchengine);
 


### PR DESCRIPTION
## Summary
This MR fixes the two issues raised in https://github.com/catalyst/moodle-search_elastic/issues/155
- The `is_server_ready` PHPUnit data provider now uses a non‑empty hostname for the “503” case so that `get_url()` returns a valid URL and triggers the status code branch.
- The search_elastic_status_checks() function in lib.php now declares global $CFG; restoring the Elastic check in `Site administration > Reports > System status`.

## Testing

1. Run the Elasticsearch testsuite:
vendor/bin/phpunit --testsuite=search_elastic_testsuite
→ All cases, including the 503 branch, should pass.
2. Log in as an administrator and navigate to `Site administration > Reports > System status`.
→ The “Elasticsearch server connection” check appears under status checks.

Closes #155 