### PR TITLE
[#157] Fix inverted hash comparison in filter_indexed_files causing full file reindex

### DIFF
--- a/classes/engine.php
+++ b/classes/engine.php
@@ -327,7 +327,7 @@ class engine extends \core_search\engine {
      * @return array   A two element array, the first is the total number of availble results, the second is an array
      *                 of documents for the current request.
      */
-    private function get_indexed_files($document, $start = 0, $rows = 500) {
+    protected function get_indexed_files($document, $start = 0, $rows = 500) {
         $url = $this->get_url();
         $indexeurl = $url . '/' . $this->config->index . '/_search';
         $client = new \search_elastic\esrequest();
@@ -505,7 +505,7 @@ class engine extends \core_search\engine {
                     // Filelib does not guarantee time modified is updated, so we will check important values.
                     $unchanged = $indexedfile->_source->modified == $files[$originalfileid]->get_timemodified()
                         && strcmp($indexedfile->_source->title, $files[$originalfileid]->get_filename()) === 0
-                        && $indexedfile->_source->filecontenthash != $files[$originalfileid]->get_contenthash();
+                        && $indexedfile->_source->filecontenthash == $files[$originalfileid]->get_contenthash();
 
                     // If the file is already indexed and unchanged, we can just remove it from the files array and skip it.
                     if ($unchanged) {

--- a/tests/engine_test.php
+++ b/tests/engine_test.php
@@ -1430,6 +1430,82 @@ final class engine_test extends \advanced_testcase {
     }
 
     /**
+     * Test that unchanged file (same hash, time and name) should be skipped and
+     * not re-indexed and not deleted from the index.
+     */
+    public function test_unchanged_file_is_skipped(): void {
+        $this->resetAfterTest();
+
+        $timemodified = time();
+        $contenthash = hash('sha1', 'testhash');
+
+        $file = $this->createMock(\stored_file::class);
+        $file->method('get_id')->willReturn(100000);
+        $file->method('get_timemodified')->willReturn($timemodified);
+        $file->method('get_contenthash')->willReturn($contenthash);
+        $file->method('get_filename')->willReturn('test.pdf');
+
+        $doc = $this->createMock(\core_search\document::class);
+        $doc->method('get_is_new')->willReturn(false);
+        $doc->method('get_files')->willReturn([100000 => $file]);
+        $doc->method('get')->willReturnMap([
+            ['id', 'parent_doc_123'],
+            ['areaid', 'core_mocksearch-mock_search_area'],
+        ]);
+
+        // Simulate that elasticsearch already has this file with the same hash, time and name.
+        $hit = (object)[
+            '_type' => 'doc',
+            '_source' => (object)[
+                'id' => 100000,
+                'modified' => $timemodified,
+                'filecontenthash' => $contenthash,
+                'title' => 'test.pdf',
+                'original_id' => null,
+            ],
+        ];
+
+        $engine = new class () extends \search_elastic\testable_engine {
+            /**
+             * @var array Hits returned by get_indexed_files().
+             */
+            private array $mockhits = [];
+
+            /**
+             * Set the hits that get_indexed_files() will return.
+             * @param array $hits
+             */
+            public function set_indexed_files(array $hits): void {
+                $this->mockhits = $hits;
+            }
+
+            #[\Override]
+            public function get_indexed_files($document, $start = 0, $rows = 500): array {
+                return [count($this->mockhits), $this->mockhits];
+            }
+
+            /**
+             * Exposes private filter_indexed_files() for unit testing via reflection.
+             * @param \core_search\document $document $document
+             * @return array
+             */
+            public function call_filter_indexed_files(\core_search\document $document): array {
+                $method = new \ReflectionMethod(engine::class, 'filter_indexed_files');
+                $method->setAccessible(true);
+                return $method->invoke($this, $document);
+            }
+        };
+        $engine->set_indexed_files([$hit]);
+        [$filestoreindex, $idstodelete] = $engine->call_filter_indexed_files($doc);
+
+        // Unchanged file should not be queued for re-indexing.
+        $this->assertArrayNotHasKey(100000, $filestoreindex);
+
+        // Unchanged file should not be scheduled for deletion.
+        $this->assertArrayNotHasKey(100000, $idstodelete);
+    }
+
+    /**
      * Helper method to create a test payload from document arrays.
      * @param array $docs
      * @return string

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026020900;
-$plugin->release   = '4.2.6 (Build: 20260209)'; // Build same as version.
+$plugin->version   = 2026051400;
+$plugin->release   = '4.2.6 (Build: 20260514)'; // Build same as version.
 $plugin->requires  = 2023042405;
 $plugin->component = 'search_elastic';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
# Summary
There was a one-character typo `!=` instead of `==` in the `filter_indexed_files()` when comparing the content hash in the `$unchanged` boolean. This meant unchanged files evaluated to `$unchanged = false` and were queued for re-indexing on every incremental run, even when nothing had changed.

# Testing Instructions
1. Create a test course
2. Create an assignment (or other module) and attach multiple files
3. Navigate to **Site administration > Server > Tasks > Scheduled task > Global search indexing (core\task\search_index_task)**
and run the indexer
4. Verify that your file has been indexed successfully
5. Update your assignment activity (e.g. title or description) and re-run the `search_index_task`
6. Check the cron logs and verify that the file is being re-indexed again

Fixes #157 