### PR TITLE
[#151] Replace deprecated setMethods with onlyMethods

### DIFF
--- a/classes/esrequest.php
+++ b/classes/esrequest.php
@@ -60,7 +60,7 @@ class esrequest {
 
         $config = [
             'timeout' => $timeout != null ? $timeout : (isset($this->config->timeout) ? intval($this->config->timeout) : 0),
-            'connect_timeout' => intval($this->config->connecttimeout),
+            'connect_timeout' => isset($this->config->connecttimeout) ? intval($this->config->connecttimeout) : 5,
         ];
 
         // Allow the caller to instantiate the Guzzle client with a custom handler.

--- a/tests/document_test.php
+++ b/tests/document_test.php
@@ -147,7 +147,7 @@ final class document_test extends \advanced_testcase {
 
         // Mock out and add missing data to stub record object.
         $builder = $this->getMockBuilder('\search_elastic\document');
-        $builder->setMethods(['_']);
+        $builder->onlyMethods([]);
         $builder->setConstructorArgs(['1', 'core_mocksearch', 'mock_search_area']);
         $stub = $builder->getMock();
 
@@ -197,7 +197,7 @@ final class document_test extends \advanced_testcase {
 
         // Mock out and add missing data to stub record object.
         $builder = $this->getMockBuilder('\search_elastic\document');
-        $builder->setMethods(['_']);
+        $builder->onlyMethods([]);
         $builder->setConstructorArgs(['1', 'core_mocksearch', 'mock_search_area']);
         $stub = $builder->getMock();
 

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026051400;
+$plugin->version   = 2026051401;
 $plugin->release   = '4.2.6 (Build: 20260514)'; // Build same as version.
 $plugin->requires  = 2023042405;
 $plugin->component = 'search_elastic';


### PR DESCRIPTION
**Description:** Updated deprecated method. Test still runs to success in Moodle 4.5:

```
root@2148dbd199be:/var/www/site# vendor/bin/phpunit --filter test_export_file_for_engine search/engine/elastic/tests/document_test.php
Moodle 4.5.11+ (Build: 20260501), 38becfa44d6eaaf99250c36f3848b9d76e135a78
Php: 8.3.31, pgsql: 17.10 (Debian 17.10-1.pgdg13+1), OS: Linux 6.17.0-29-generic x86_64
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:00.232, Memory: 70.50 MB

OK (1 test, 4 assertions)
root@2148dbd199be:/var/www/cat-moo#
```