### PR TITLE
Issue #151: Resolved unit tests for Moodle 5.1+

### DIFF
--- a/tests/esrequest_test.php
+++ b/tests/esrequest_test.php
@@ -93,10 +93,10 @@ final class esrequest_test extends \advanced_testcase {
      * The GuzzleHttp exception is no longer be throwed
      */
     public function test_get_unreachable_host(): void {
-        $this->expectException(\GuzzleHttp\Exception\ConnectException::class);
         $url = 'http://unreachable:9020';
         $client = new \search_elastic\esrequest();
         $response = $client->get($url);
+        $this->assertEquals(503, $response->getStatusCode());
     }
 
     /**

--- a/tests/local/chunking/fixed_size_test.php
+++ b/tests/local/chunking/fixed_size_test.php
@@ -107,9 +107,9 @@ final class fixed_size_test extends advanced_testcase {
      * @dataProvider chunk_overlap_provider
      * @param int $maxsize
      * @param int $overlap
-     * @param int $exceptednumchunks
+     * @param int $expectednumchunks
      */
-    public function test_chunk_with_overlap(int $maxsize, int $overlap, int $exceptednumchunks): void {
+    public function test_chunk_with_overlap(int $maxsize, int $overlap, int $expectednumchunks): void {
         $rec = new stdClass();
         $rec->content = <<<EOF
         Lorem Ipsum is simply dummy text of the printing and typesetting industry.
@@ -128,11 +128,12 @@ final class fixed_size_test extends advanced_testcase {
         $options = [
             'maxsize' => $maxsize,
             'overlap' => $overlap,
+            'expectednumchunks' => $expectednumchunks,
         ];
 
         $chunkingstrategy = new fixed_size();
         $chunks = $chunkingstrategy->chunk($docdata['content'], $options);
-        $this->assertCount($exceptednumchunks, $chunks);
+        $this->assertCount($expectednumchunks, $chunks);
 
         // Last chunk should include end of text.
         $lastchunk = $chunks[count($chunks) - 1]['text'];

--- a/tests/server_ready_check_test.php
+++ b/tests/server_ready_check_test.php
@@ -66,10 +66,10 @@ final class server_ready_check_test extends advanced_testcase {
      * Tests check result.
      *
      * @param string $hostname
-     * @param string $expectedstatus
+     * @param string $status
      * @dataProvider server_ready_provider
      */
-    public function test_check(string $hostname, string $expectedstatus): void {
+    public function test_check(string $hostname, string $status): void {
         $this->resetAfterTest();
         set_config('hostname', $hostname, 'search_elastic');
 
@@ -86,7 +86,7 @@ final class server_ready_check_test extends advanced_testcase {
 
         $check = new server_ready_check($stack);
         $result = $check->get_result();
-        $this->assertEquals($expectedstatus, $result->get_status());
+        $this->assertEquals($status, $result->get_status());
     }
 
     /**


### PR DESCRIPTION
Closes issue #151.

Updated `search_elastic\esrequest_test::test_get_unreachable_host` to expect a 503 status code for an unreachable host. This logic was updated in the plugin, but not in the test.

There were some variables with different names in the test provider than what was being checked in the tests. I've updated the tests to reflect the same variable names in the test to get rid of the errors.
```
Error: Unknown named parameter $status
Error: Unknown named parameter $expectednumchunks
```
## Environment
```
- Moodle 5.1.3+ (Build: 20260220)
- PHP: 8.4.22
- DB: MySQL 8.4
- Branch: MOODLE_404_STABLE
```

## Testing instructions:
- `search_elastic` test suite: `vendor/bin/phpunit --testsuite search_elastic_testsuite`
- Running the unit tests for `search_elastic` will produce the following errors (on the above environment):
```
Moodle 5.1.3+ (Build: 20260220)
Php: 8.4.22, mysqli: 8.4.9, OS: Linux 6.17.0-1025-oem x86_64
PHPUnit 11.5.12 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-mdl/phpunit.xml

.....SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS.....F..........SSSS  63 / 189 ( 33%)
SSSSSSSSSEEEE.................................................. 126 / 189 ( 66%)
...........................................................EEE. 189 / 189 (100%)


Time: 00:19.818, Memory: 87.50 MB

There were 7 errors:

1) search_elastic\local\chunking\fixed_size_test::test_chunk_with_overlap with data set "No overlap" (200, 0, 3)
Error: Unknown named parameter $expectednumchunks

2) search_elastic\local\chunking\fixed_size_test::test_chunk_with_overlap with data set "No overlap larger max size" (2000, 0, 1)
Error: Unknown named parameter $expectednumchunks

3) search_elastic\local\chunking\fixed_size_test::test_chunk_with_overlap with data set "Max size greater than text length with overlap" (2000, 100, 1)
Error: Unknown named parameter $expectednumchunks

4) search_elastic\local\chunking\fixed_size_test::test_chunk_with_overlap with data set "Max size less than text length with overlap" (400, 10, 2)
Error: Unknown named parameter $expectednumchunks

5) search_elastic\server_ready_check_test::test_check with data set "not set" ('', 'na')
Error: Unknown named parameter $status

6) search_elastic\server_ready_check_test::test_check with data set "invalid hostname" ('invalid.com', 'error')
Error: Unknown named parameter $status

7) search_elastic\server_ready_check_test::test_check with data set "valid hostname" ('valid.com', 'ok')
Error: Unknown named parameter $status

--

There was 1 failure:

1) search_elastic\esrequest_test::test_get_unreachable_host
Failed asserting that exception of type "GuzzleHttp\Exception\ConnectException" is thrown.
```
### Expected Output from PHPUnit Tests
- Pulling this branch `MOODLE_404_STABLE-issue151` and re-running the testsuite:
```
Moodle 5.1.3+ (Build: 20260220)
Php: 8.4.22, mysqli: 8.4.9, OS: Linux 6.17.0-1025-oem x86_64
PHPUnit 11.5.12 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-mdl/phpunit.xml

.....SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS................SSSS  63 / 189 ( 33%)
SSSSSSSSS...................................................... 126 / 189 ( 66%)
............................................................... 189 / 189 (100%)


Time: 00:40.370, Memory: 87.50 MB

OK, but there were issues!
Tests: 189, Assertions: 459, PHPUnit Deprecations: 23, Skipped: 51.
```