### PR TITLE
Fix #164: test only delete engine if it has been setup

### DIFF
--- a/tests/engine_test.php
+++ b/tests/engine_test.php
@@ -130,8 +130,10 @@ final class engine_test extends \advanced_testcase {
             $this->generator->teardown();
             $this->generator = null;
         }
-        $this->engine->delete();
-        sleep(1);
+        if ($this->engine) {
+            $this->engine->delete();
+            sleep(1);
+        }
         parent::tearDown();
     }
 

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -111,7 +111,9 @@ final class externallib_test extends \advanced_testcase {
             $this->generator->teardown();
             $this->generator = null;
         }
-        $this->engine->delete('core_mocksearch-mock_search_area');
+        if ($this->engine) {
+            $this->engine->delete('core_mocksearch-mock_search_area');
+        }
         parent::tearDown();
     }
 

--- a/tests/local/chunking/chunking_engine_test.php
+++ b/tests/local/chunking/chunking_engine_test.php
@@ -126,8 +126,10 @@ final class chunking_engine_test extends advanced_testcase {
             $this->generator->teardown();
             $this->generator = null;
         }
-        $this->engine->delete();
-        sleep(1);
+        if ($this->engine) {
+            $this->engine->delete();
+            sleep(1);
+        }
         parent::tearDown();
     }
 


### PR DESCRIPTION
This fix #164 when search elastic is not configured

```

root@cb0f2909efca:/var/www/catalyst-moodle# vendor/bin/phpunit --testsuite=search_elastic_testsuite
Moodle 5.2.1+ (Build: 20260616)
Php: 8.4.22, pgsql: 17.5 (Debian 17.5-1.pgdg120+1), OS: Linux 6.17.0-35-generic x86_64
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/catalyst-moodle/phpunit.xml

.....SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS................SSSS  63 / 189 ( 33%)
SSSSSSSSS...................................................... 126 / 189 ( 66%)
............................................................... 189 / 189 (100%)


Time: 00:28.984, Memory: 91.00 MB

```

