### PR TITLE
[#168] Fix fileid backfill and save_error for chunked file docids

### DIFF
--- a/classes/local/service/error_service.php
+++ b/classes/local/service/error_service.php
@@ -97,7 +97,7 @@ class error_service {
         global $DB;
 
         $now = time();
-        $fileid = is_numeric($documentid) ? (int)$documentid : null;
+        $fileid = self::extract_fileid($documentid);
 
         $select = $DB->sql_compare_text('docid') . ' = :docid AND errortype = :errortype';
         $params = [
@@ -133,6 +133,23 @@ class error_service {
             $error->set('parentid', $parentid);
             $error->create();
         }
+    }
+
+    /**
+     * Extracts the file id from a file document id, handling chunked docids.
+     *
+     * File docids are purely numeric, optionally with a chunk suffix when chunking is
+     * enabled (e.g. '123' or '123_c1'). Non-file docids always contain a '-'
+     * (e.g. mod_assign-activity-123 or mod_assign-activity-123_c1).
+     *
+     * @param string $documentid Document ID that may represent a file.
+     * @return int|null The file id, or null if the document id is not a file document.
+     */
+    private static function extract_fileid($documentid): ?int {
+        if (preg_match('/^(\d+)(?:_c\d+)?$/', (string)$documentid, $matches)) {
+            return (int) $matches[1];
+        }
+        return null;
     }
 
     /**

--- a/classes/local/service/error_service.php
+++ b/classes/local/service/error_service.php
@@ -145,8 +145,8 @@ class error_service {
      * @param string $documentid Document ID that may represent a file.
      * @return int|null The file id, or null if the document id is not a file document.
      */
-    private static function extract_fileid($documentid): ?int {
-        if (preg_match('/^(\d+)(?:_c\d+)?$/', (string)$documentid, $matches)) {
+    private static function extract_fileid(string $documentid): ?int {
+        if (preg_match('/^(\d+)(?:_c\d+)?$/', $documentid, $matches)) {
             return (int) $matches[1];
         }
         return null;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -118,10 +118,21 @@ function xmldb_search_elastic_upgrade($oldversion) {
             $dbman->add_field($table, $field);
         }
 
-        // Backfill fileid for existing rows where docid is a plain integer (file documents).
-        // File docids are purely numeric and non-file docids always contain '-' (e.g. mod_assign-activity-123).
-        $docidcast = $DB->sql_cast_char2int('docid');
-        $DB->execute("UPDATE {search_elastic_errors} SET fileid = {$docidcast} WHERE docid NOT LIKE '%-%'");
+        // Backfill fileid for existing rows where docid represents a file document.
+        // File docids are purely numeric, optionally with a chunk suffix when chunking is
+        // enabled (e.g. '123' or '123_c1'). Non-file docids always contain a '-'
+        // (e.g. mod_assign-activity-123 or mod_assign-activity-123_c1), so filtering those
+        // out first and then stripping any chunk suffix in PHP avoids relying on a DB cast
+        // that can fail or silently truncate on docids like '123_c1'.
+        $select = $DB->sql_like('docid', ':pattern', true, true, true);
+        $rs = $DB->get_recordset_select('search_elastic_errors', $select, ['pattern' => '%-%']);
+        foreach ($rs as $record) {
+            if (preg_match('/^(\d+)(?:_c\d+)?$/', $record->docid, $matches)) {
+                $record->fileid = (int) $matches[1];
+                $DB->update_record('search_elastic_errors', $record);
+            }
+        }
+        $rs->close();
 
         upgrade_plugin_savepoint(true, 2026051404, 'search', 'elastic');
     }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -110,7 +110,7 @@ function xmldb_search_elastic_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2025062708, 'search', 'elastic');
     }
 
-    if ($oldversion < 2026051404) {
+    if ($oldversion < 2026051405) {
         $table = new xmldb_table('search_elastic_errors');
 
         $field = new xmldb_field('fileid', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'docid');
@@ -134,7 +134,7 @@ function xmldb_search_elastic_upgrade($oldversion) {
         }
         $rs->close();
 
-        upgrade_plugin_savepoint(true, 2026051404, 'search', 'elastic');
+        upgrade_plugin_savepoint(true, 2026051405, 'search', 'elastic');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -124,15 +124,18 @@ function xmldb_search_elastic_upgrade($oldversion) {
         // (e.g. mod_assign-activity-123 or mod_assign-activity-123_c1), so filtering those
         // out first and then stripping any chunk suffix in PHP avoids relying on a DB cast
         // that can fail or silently truncate on docids like '123_c1'.
-        $select = $DB->sql_like('docid', ':pattern', true, true, true);
+        $select = $DB->sql_like('docid', ':pattern', true, true, true) . ' AND fileid IS NULL';
         $rs = $DB->get_recordset_select('search_elastic_errors', $select, ['pattern' => '%-%']);
-        foreach ($rs as $record) {
-            if (preg_match('/^(\d+)(?:_c\d+)?$/', $record->docid, $matches)) {
-                $record->fileid = (int) $matches[1];
-                $DB->update_record('search_elastic_errors', $record);
+        try {
+            foreach ($rs as $record) {
+                if (preg_match('/^(\d+)(?:_c\d+)?$/', $record->docid, $matches)) {
+                    $record->fileid = (int) $matches[1];
+                    $DB->update_record('search_elastic_errors', $record);
+                }
             }
+        } finally {
+            $rs->close();
         }
-        $rs->close();
 
         upgrade_plugin_savepoint(true, 2026051405, 'search', 'elastic');
     }

--- a/tests/local/service/error_service_test.php
+++ b/tests/local/service/error_service_test.php
@@ -168,6 +168,47 @@ final class error_service_test extends advanced_testcase {
     }
 
     /**
+     * Data provider for test_save_error_fileid.
+     *
+     * @return array
+     */
+    public static function save_error_fileid_provider(): array {
+        return [
+            'plain file docid' => ['123', 123],
+            'chunked file docid' => ['123_c1', 123],
+            'chunked file docid, later chunk' => ['456_c12', 456],
+            'non-file docid' => ['mod_assign-activity-123', null],
+            'chunked non-file docid' => ['mod_assign-activity-123_c1', null],
+            'non-numeric docid' => ['test_doc_123', null],
+        ];
+    }
+
+    /**
+     * Test that save_error correctly derives fileid from the docid, including
+     * chunked file docids (e.g. '123_c1') produced when chunking is enabled.
+     *
+     * @dataProvider save_error_fileid_provider
+     * @param string $docid Document ID to save the error against.
+     * @param int|null $expectedfileid Expected fileid stored on the error record.
+     */
+    public function test_save_error_fileid(string $docid, ?int $expectedfileid): void {
+        global $DB;
+
+        error_service::save_error(
+            $docid,
+            456,
+            $this->coursecontext->id,
+            'core_mocksearch-mock_search_area',
+            error::TYPE_INDEXING,
+            'Test error message',
+            time()
+        );
+
+        $error = $DB->get_record('search_elastic_errors', ['docid' => $docid]);
+        $this->assertEquals($expectedfileid, $error->fileid);
+    }
+
+    /**
      * Test get_error_count_by_status method.
      */
     public function test_get_error_count_by_status(): void {

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026051404;
+$plugin->version   = 2026051405;
 $plugin->release   = '4.2.6 (Build: 20260514)'; // Build same as version.
 $plugin->requires  = 2023042405;
 $plugin->component = 'search_elastic';


### PR DESCRIPTION
# Testing Instructions

**Verify the upgrade backfill**
1. On a test site, insert some rows in  `search_elastic_errors`  to cover each case (or use ones already there from testing chunking):

-  `docid = '123'` (plain file, not chunked) → should backfill to `fileid = 123`
-  `docid = '123_c1'` (chunked file) → should backfill to `fileid = 123`
-  `docid = 'mod_assign-activity-123'` (non-file) → `fileid` stays `null`
-  `docid = 'mod_assign-activity-123_c1'` (non-file, chunked) → `fileid` stays `null`

2. Set the plugin version back below `2026051405` and navigate to `<moodlesite>/admin/index.php` (or CLI upgrade) to trigger the upgrade step, then check the `fileid` column matches the expectations above.
